### PR TITLE
Upgrade typechain

### DIFF
--- a/containers/Contracts.ts
+++ b/containers/Contracts.ts
@@ -3,52 +3,52 @@ import { createContainer } from "unstated-next";
 import { ethers } from "ethers";
 import { Connection } from "./Connection";
 
-import { CurveProxyLogic } from "./Contracts/CurveProxyLogic";
-import { CurveProxyLogicFactory } from "./Contracts/CurveProxyLogicFactory";
-import { Uniswapv2ProxyLogic } from "./Contracts/Uniswapv2ProxyLogic";
-import { Uniswapv2ProxyLogicFactory } from "./Contracts/Uniswapv2ProxyLogicFactory";
-import { Strategy } from "./Contracts/Strategy";
-import { StrategyFactory } from "./Contracts/StrategyFactory";
-import { Comptroller } from "./Contracts/Comptroller";
-import { ComptrollerFactory } from "./Contracts/ComptrollerFactory";
-import { Ctoken } from "./Contracts/Ctoken";
-import { CtokenFactory } from "./Contracts/CtokenFactory";
-import { Masterchef } from "./Contracts/Masterchef";
-import { GaugeController } from "./Contracts/GaugeController";
-import { CurveGauge } from "./Contracts/CurveGauge";
-import { Pool } from "./Contracts/Pool";
-import { Controller } from "./Contracts/Controller";
-import { Erc20 } from "./Contracts/Erc20";
-import { Uniswapv2Pair } from "./Contracts/Uniswapv2Pair";
-import { MasterchefFactory } from "./Contracts/MasterchefFactory";
-import { GaugeControllerFactory } from "./Contracts/GaugeControllerFactory";
-import { CurveGaugeFactory } from "./Contracts/CurveGaugeFactory";
-import { PoolFactory } from "./Contracts/PoolFactory";
-import { StakingRewards } from "./Contracts/StakingRewards";
-import { StakingRewardsFactory } from "./Contracts/StakingRewardsFactory";
 import { BasisStaking } from "./Contracts/BasisStaking";
-import { BasisStakingFactory } from "./Contracts/BasisStakingFactory";
-import { ControllerFactory } from "./Contracts/ControllerFactory";
-import { Erc20Factory } from "./Contracts/Erc20Factory";
-import { Uniswapv2PairFactory } from "./Contracts/Uniswapv2PairFactory";
-import { Instabrine } from "./Contracts/Instabrine";
-import { InstabrineFactory } from "./Contracts/InstabrineFactory";
-import { SushiChef } from "./Contracts/SushiChef";
-import { SushiChefFactory } from "./Contracts/SushiChefFactory";
+import { BasisStaking__factory as BasisStakingFactory } from "./Contracts/factories/BasisStaking__factory";
+import { Comptroller } from "./Contracts/Comptroller";
+import { Comptroller__factory as ComptrollerFactory } from "./Contracts/factories/Comptroller__factory";
+import { Controller } from "./Contracts/Controller";
+import { Controller__factory as ControllerFactory } from "./Contracts/factories/Controller__factory";
+import { Ctoken } from "./Contracts/Ctoken";
+import { Ctoken__factory as CtokenFactory } from "./Contracts/factories/Ctoken__factory";
+import { CurveGauge } from "./Contracts/CurveGauge";
+import { CurveGauge__factory as CurveGaugeFactory } from "./Contracts/factories/CurveGauge__factory";
+import { CurveProxyLogic } from "./Contracts/CurveProxyLogic";
+import { CurveProxyLogic__factory as CurveProxyLogicFactory } from "./Contracts/factories/CurveProxyLogic__factory";
 import { Dill } from "./Contracts/Dill";
-import { DillFactory } from "./Contracts/DillFactory";
-import { Gauge } from "./Contracts/Gauge";
-import { GaugeFactory } from "./Contracts/GaugeFactory";
-import { GaugeProxy } from "./Contracts/GaugeProxy";
-import { GaugeProxyFactory } from "./Contracts/GaugeProxyFactory";
-import { FeeDistributorFactory } from "./Contracts/FeeDistributorFactory";
+import { Dill__factory as DillFactory } from "./Contracts/factories/Dill__factory";
+import { Erc20 } from "./Contracts/Erc20";
+import { Erc20__factory as Erc20Factory } from "./Contracts/factories/Erc20__factory";
 import { FeeDistributor } from "./Contracts/FeeDistributor";
-import { YvecrvZap } from "./Contracts/YvecrvZap";
-import { YvecrvZapFactory } from "./Contracts/YvecrvZapFactory";
-import { YvboostMigrator } from "./Contracts/YvboostMigrator";
-import { YvboostMigratorFactory } from "./Contracts/YvboostMigratorFactory";
+import { FeeDistributor__factory as FeeDistributorFactory } from "./Contracts/factories/FeeDistributor__factory";
+import { Gauge } from "./Contracts/Gauge";
+import { Gauge__factory as GaugeFactory } from "./Contracts/factories/Gauge__factory";
+import { GaugeController } from "./Contracts/GaugeController";
+import { GaugeController__factory as GaugeControllerFactory } from "./Contracts/factories/GaugeController__factory";
+import { GaugeProxy } from "./Contracts/GaugeProxy";
+import { GaugeProxy__factory as GaugeProxyFactory } from "./Contracts/factories/GaugeProxy__factory";
+import { Instabrine } from "./Contracts/Instabrine";
+import { Instabrine__factory as InstabrineFactory } from "./Contracts/factories/Instabrine__factory";
+import { Masterchef } from "./Contracts/Masterchef";
+import { Masterchef__factory as MasterchefFactory } from "./Contracts/factories/Masterchef__factory";
+import { Pool } from "./Contracts/Pool";
+import { Pool__factory as PoolFactory } from "./Contracts/factories/Pool__factory";
 import { StakingPools } from "./Contracts/StakingPools";
-import { StakingPoolsFactory } from "./Contracts/StakingPoolsFactory";
+import { StakingPools__factory as StakingPoolsFactory } from "./Contracts/factories/StakingPools__factory";
+import { StakingRewards } from "./Contracts/StakingRewards";
+import { StakingRewards__factory as StakingRewardsFactory } from "./Contracts/factories/StakingRewards__factory";
+import { Strategy } from "./Contracts/Strategy";
+import { Strategy__factory as StrategyFactory } from "./Contracts/factories/Strategy__factory";
+import { SushiChef } from "./Contracts/SushiChef";
+import { SushiChef__factory as SushiChefFactory } from "./Contracts/factories/SushiChef__factory";
+import { Uniswapv2Pair } from "./Contracts/Uniswapv2Pair";
+import { Uniswapv2Pair__factory as Uniswapv2PairFactory } from "./Contracts/factories/Uniswapv2Pair__factory";
+import { Uniswapv2ProxyLogic } from "./Contracts/Uniswapv2ProxyLogic";
+import { Uniswapv2ProxyLogic__factory as Uniswapv2ProxyLogicFactory } from "./Contracts/factories/Uniswapv2ProxyLogic__factory";
+import { YvboostMigrator } from "./Contracts/YvboostMigrator";
+import { YvboostMigrator__factory as YvboostMigratorFactory } from "./Contracts/factories/YvboostMigrator__factory";
+import { YvecrvZap } from "./Contracts/YvecrvZap";
+import { YvecrvZap__factory as YvecrvZapFactory } from "./Contracts/factories/YvecrvZap__factory";
 
 export const PICKLE_STAKING_SCRV_REWARDS =
   "0xd86f33388bf0bfdf0ccb1ecb4a48a1579504dc0a";
@@ -243,8 +243,12 @@ function useContracts() {
       setGauge(GaugeFactory.connect(ethers.constants.AddressZero, signer));
       setFeeDistributor(FeeDistributorFactory.connect(FEE_DISTRIBUTOR, signer));
       setYveCrvZap(YvecrvZapFactory.connect(YVECRV_ZAP, signer));
-      setyvBoostMigrator(YvboostMigratorFactory.connect(YVBOOST_MIGRATOR, signer));
-      setStakingPools(StakingPoolsFactory.connect(ALCHEMIX_ALCX_ETH_STAKING_POOLS, signer));
+      setyvBoostMigrator(
+        YvboostMigratorFactory.connect(YVBOOST_MIGRATOR, signer),
+      );
+      setStakingPools(
+        StakingPoolsFactory.connect(ALCHEMIX_ALCX_ETH_STAKING_POOLS, signer),
+      );
     }
   };
 
@@ -282,7 +286,7 @@ function useContracts() {
     feeDistributor,
     yveCrvZap,
     yvBoostMigrator,
-    stakingPools
+    stakingPools,
   };
 }
 

--- a/containers/Dill.ts
+++ b/containers/Dill.ts
@@ -50,7 +50,6 @@ export function useDill(): UseDillOutput {
         const dillContract = dill.attach(DILL);
         const feeDistributorContract = feeDistributor.attach(FEE_DISTRIBUTOR);
 
-
         const [
           lockStats,
           balance,
@@ -69,9 +68,11 @@ export function useDill(): UseDillOutput {
           feeDistributorContract["time_cursor()"]({ gasLimit: 1000000 }),
         ]);
 
-        const lastDistribution = await feeDistributorContract["tokens_per_week(uint256)"](timeCursor.sub(ethers.BigNumber.from(WEEK)),{
+        const lastDistribution = await feeDistributorContract[
+          "tokens_per_week(uint256)"
+        ](timeCursor.sub(ethers.BigNumber.from(WEEK)), {
           gasLimit: 1000000,
-        }) 
+        });
 
         const totalLockedValue =
           prices.pickle * parseFloat(ethers.utils.formatEther(totalSupply));

--- a/containers/Jars/useFetchJars.ts
+++ b/containers/Jars/useFetchJars.ts
@@ -2,9 +2,9 @@ import { useState, useEffect } from "react";
 
 import { Strategy as StrategyContract } from "../Contracts/Strategy";
 import { Jar as JarContract } from "../Contracts/Jar";
-import { JarFactory } from "../Contracts/JarFactory";
+import { Jar__factory as JarFactory } from "../Contracts/factories/Jar__factory";
 import { Erc20 as Erc20Contract } from "../Contracts/Erc20";
-import { Erc20Factory } from "../Contracts/Erc20Factory";
+import { Erc20__factory as Erc20Factory } from "../Contracts/factories/Erc20__factory";
 
 import { Connection } from "../Connection";
 import { Contracts } from "../Contracts";

--- a/features/Balances/useBalances.ts
+++ b/features/Balances/useBalances.ts
@@ -31,7 +31,7 @@ export const useBalances = (): IUseBalances => {
       setPickleBN(balanceBN);
 
       // get pickle total supply
-      const totalSupplyBN = (await pickle.totalSupply()) as BigNumber;
+      const totalSupplyBN = await pickle.totalSupply();
       const totalSupply = ethers.utils.formatUnits(totalSupplyBN);
       setTotalSupply(Number(totalSupply));
     }

--- a/features/DILL/Lock/CreateLock.tsx
+++ b/features/DILL/Lock/CreateLock.tsx
@@ -18,7 +18,6 @@ import {
   getEpochSecondForDay,
   getWeekDiff,
 } from "../../../util/date";
-import { SelectPeriod } from "../../../components/SelectPeriod";
 import {
   estimateDillForDate,
   estimateDillForPeriod,

--- a/features/Farms/UseMigrate.ts
+++ b/features/Farms/UseMigrate.ts
@@ -1,8 +1,7 @@
 import { BigNumber, ethers } from "ethers";
-import { useEffect, useState } from "react";
 import { Connection } from "../../containers/Connection";
 import { Contracts } from "../../containers/Contracts";
-import { GaugeFactory } from "../../containers/Contracts/GaugeFactory";
+import { Gauge__factory as GaugeFactory } from "../../containers/Contracts/factories/Gauge__factory";
 import { Erc20 } from "../../containers/Contracts/Erc20";
 import { PICKLE_JARS } from "../../containers/Jars/jars";
 import { getStats } from "../../features/Zap/useZapper";
@@ -92,10 +91,9 @@ export const useMigrate = (
     await tx.wait();
   };
 
-
   const withdrawGauge = async (gauge: Gauge) => {
     if (!address || !gauge || !parseInt(staked.toString())) return;
-  
+
     const tx = await gauge.exit();
     await tx.wait();
   };

--- a/features/Gauges/GaugeCollapsible.tsx
+++ b/features/Gauges/GaugeCollapsible.tsx
@@ -28,7 +28,7 @@ import Collapse from "../Collapsible/Collapse";
 import { JarApy } from "../../containers/Jars/useJarsWithAPY";
 import { useUniPairDayData } from "../../containers/Jars/useUniPairDayData";
 import { LpIcon, TokenIcon } from "../../components/TokenIcon";
-import { GaugeFactory } from "../../containers/Contracts/GaugeFactory";
+import { Gauge__factory as GaugeFactory } from "../../containers/Contracts/factories/Gauge__factory";
 import { FARM_LP_TO_ICON } from "../Farms/FarmCollapsible";
 import { useDill } from "../../containers/Dill";
 import { useMigrate } from "../Farms/UseMigrate";
@@ -103,12 +103,13 @@ export const GaugeCollapsible: FC<{ gaugeData: UserGaugeData }> = ({
   const { balance: dillBalance, totalSupply: dillSupply } = useDill();
   const stakedNum = parseFloat(formatEther(staked));
   const balanceNum = parseFloat(formatEther(balance));
-  const { deposit, withdraw, migrateYvboost, depositYvboost, withdrawGauge } = useMigrate(
-    depositToken,
-    0,
-    balance,
-    staked,
-  );
+  const {
+    deposit,
+    withdraw,
+    migrateYvboost,
+    depositYvboost,
+    withdrawGauge,
+  } = useMigrate(depositToken, 0, balance, staked);
   const valueStr = (stakedNum * usdPerToken).toLocaleString(undefined, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
@@ -494,10 +495,18 @@ export const GaugeCollapsible: FC<{ gaugeData: UserGaugeData }> = ({
                 }}
               >
                 Your tokens will be unstaked and migrated to the yvBOOST pJar
-                and staked in the Farm.<br />
+                and staked in the Farm.
+                <br />
                 This process will require a number of transactions.
-                <br/>
-            Learn more about yvBOOST <a target="_" href="https://twitter.com/iearnfinance/status/1388131568481411077">here</a>.
+                <br />
+                Learn more about yvBOOST{" "}
+                <a
+                  target="_"
+                  href="https://twitter.com/iearnfinance/status/1388131568481411077"
+                >
+                  here
+                </a>
+                .
                 {isSuccess ? (
                   <p style={{ fontWeight: "bold" }}>
                     Migration completed! See your deposits{" "}

--- a/features/Zap/useBalance.ts
+++ b/features/Zap/useBalance.ts
@@ -1,6 +1,6 @@
 import { BigNumber, ethers } from "ethers";
 import { useEffect, useState } from "react";
-import { Erc20Factory } from "../../containers/Contracts/Erc20Factory";
+import { Erc20__factory as Erc20Factory } from "../../containers/Contracts/factories/Erc20__factory";
 import { Connection } from "../../containers/Connection";
 
 const tokenInfo = {

--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
     "react-dom": "^16.13.1",
     "react-is": "^16.13.1",
     "react-jazzicon": "^0.1.3",
+    "react-loader-spinner": "^4.0.0",
     "react-number-format": "^4.4.4",
     "react-query": "^3.12.0",
     "recharts": "^2.0.8",
-    "react-loader-spinner": "^4.0.0",
     "recharts-scale": "^0.4.3",
     "rxjs": "^6.6.3",
     "sass": "^1.26.11",
@@ -56,7 +56,7 @@
     "unstated-next": "^1.1.0"
   },
   "devDependencies": {
-    "@typechain/ethers-v5": "^1.0.0",
+    "@typechain/ethers-v5": "^6.0.0",
     "@types/eslint": "^7.2.6",
     "@types/node": "^14.11.1",
     "@types/node-fetch": "^2.5.8",
@@ -76,7 +76,7 @@
     "husky": ">=4",
     "lint-staged": ">=10",
     "prettier": "2.1.2",
-    "typechain": "^2.0.0",
+    "typechain": "^4.0.0",
     "typescript": "^4.0.3",
     "typesync": "^0.8.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1952,12 +1952,10 @@
   dependencies:
     "@openzeppelin/contracts" "^2.5.0"
 
-"@typechain/ethers-v5@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@typechain/ethers-v5/-/ethers-v5-1.0.0.tgz"
-  integrity sha512-CWxLmlmfM7NMT6OSq8UXZM7mSkHU1xrbNi40Hvj26S97jKnwERmNbiERgy4fXXOdVqb+zCshnZQ9X+P5WndLMA==
-  dependencies:
-    ethers "^5.0.2"
+"@typechain/ethers-v5@^6.0.0":
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/@typechain/ethers-v5/-/ethers-v5-6.0.5.tgz#39bbf9baadd0e8d9efad9d16c60152b7cd9a467b"
+  integrity sha512-KJh+EWuxmX1a17fQWS1ba8DCYcqK7UpdbqMZZwyfiv9FQfn8ZQJX17anbkCMOSU8TV3EvRuJ/vFEKGzKnpkO8g==
 
 "@types/bn.js@^4.11.3":
   version "4.11.6"
@@ -2085,10 +2083,10 @@
   resolved "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.2.tgz"
   integrity sha512-IiPhNnenzkqdSdQH3ifk9LoX7oQe61ZlDdDO4+MUv6FyWdPGDPr26gCPVs3oguZEMq//nFZZpwUZcVuNJsG+DQ==
 
-"@types/prettier@^1.13.2":
-  version "1.19.1"
-  resolved "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz"
-  integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
+"@types/prettier@^2.1.1":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.3.tgz#ef65165aea2924c9359205bf748865b8881753c0"
+  integrity sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==
 
 "@types/prop-types@*":
   version "15.7.3"
@@ -4790,7 +4788,7 @@ ethers-multicall@^0.1.3:
   dependencies:
     ethers "^5.0.0"
 
-ethers@^5.0.0, ethers@^5.0.14, ethers@^5.0.2:
+ethers@^5.0.0, ethers@^5.0.14:
   version "5.0.14"
   resolved "https://registry.npmjs.org/ethers/-/ethers-5.0.14.tgz"
   integrity sha512-6WkoYwAURTr/4JiSZlrMJ9mm3pBv/bWrOu7sVXdLGw9QU4cp/GDZVrKKnh5GafMTzanuNBJoaEanPCjsbe4Mig==
@@ -7299,10 +7297,10 @@ prettier@2.1.2:
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz"
   integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
 
-prettier@^1.14.2:
-  version "1.19.1"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.1.2:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -8706,23 +8704,23 @@ ts-essentials@^1.0.0:
   resolved "https://registry.npmjs.org/ts-essentials/-/ts-essentials-1.0.4.tgz"
   integrity sha512-q3N1xS4vZpRouhYHDPwO0bDW3EZ6SK9CrrDHxi/D6BPReSjpVgWIOpLS2o0gSBZm+7q/wyKp6RVM1AeeW7uyfQ==
 
-ts-essentials@^6.0.3:
-  version "6.0.7"
-  resolved "https://registry.npmjs.org/ts-essentials/-/ts-essentials-6.0.7.tgz"
-  integrity sha512-2E4HIIj4tQJlIHuATRHayv0EfMGK3ris/GRk1E3CFnsZzeNV+hUmelbaTZHLtXaZppM5oLhHRtO04gINC4Jusw==
+ts-essentials@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-7.0.1.tgz#d205508cae0cdadfb73c89503140cf2228389e2d"
+  integrity sha512-8lwh3QJtIc1UWhkQtr9XuksXu3O0YQdEE5g79guDfhCaU1FWTDIEDZ1ZSx4HTHUmlJZ8L812j3BZQ4a0aOUkSA==
 
-ts-generator@^0.0.8:
-  version "0.0.8"
-  resolved "https://registry.npmjs.org/ts-generator/-/ts-generator-0.0.8.tgz"
-  integrity sha512-Gi+aZCELpVL7Mqb+GuMgM+n8JZ/arZZib1iD/R9Ok8JDjOCOCrqS9b1lr72ku7J45WeDCFZxyJoRsiQvhokCnw==
+ts-generator@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ts-generator/-/ts-generator-0.1.1.tgz#af46f2fb88a6db1f9785977e9590e7bcd79220ab"
+  integrity sha512-N+ahhZxTLYu1HNTQetwWcx3so8hcYbkKBHTr4b4/YgObFTIKkOSSsaa+nal12w8mfrJAyzJfETXawbNjSfP2gQ==
   dependencies:
     "@types/mkdirp" "^0.5.2"
-    "@types/prettier" "^1.13.2"
+    "@types/prettier" "^2.1.1"
     "@types/resolve" "^0.0.8"
     chalk "^2.4.1"
     glob "^7.1.2"
     mkdirp "^0.5.1"
-    prettier "^1.14.2"
+    prettier "^2.1.2"
     resolve "^1.8.1"
     ts-essentials "^1.0.0"
 
@@ -8802,18 +8800,18 @@ type@^2.0.0:
   resolved "https://registry.npmjs.org/type/-/type-2.1.0.tgz"
   integrity sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==
 
-typechain@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/typechain/-/typechain-2.0.0.tgz"
-  integrity sha512-O+hsAUwtBpqCfoq46Grm52OEdm0GBEu78LxrEzkkGdwUdCoCZpNb2HPzPoNB1MXiRnNhEOGMFyf05UbT2/bUEw==
+typechain@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typechain/-/typechain-4.0.3.tgz#e8fcd6c984676858c64eeeb155ea783a10b73779"
+  integrity sha512-tmoHQeXZWHxIdeLK+i6dU0CU0vOd9Cndr3jFTZIMzak5/YpFZ8XoiYpTZcngygGBqZo+Z1EUmttLbW9KkFZLgQ==
   dependencies:
     command-line-args "^4.0.7"
     debug "^4.1.1"
     fs-extra "^7.0.0"
     js-sha3 "^0.8.0"
     lodash "^4.17.15"
-    ts-essentials "^6.0.3"
-    ts-generator "^0.0.8"
+    ts-essentials "^7.0.1"
+    ts-generator "^0.1.1"
 
 typedarray-to-buffer@3.1.5:
   version "3.1.5"


### PR DESCRIPTION
I noticed `@typechain/ethers-v5` was generating outdated types, this brings it up to date.

Changes
- factories are now moved inside a `factories` subfolder and suffixed with `__factory` by default