### PR TITLE
Remove extra forward slash from API routes

### DIFF
--- a/util/api.js
+++ b/util/api.js
@@ -1,6 +1,6 @@
 import fetch from "node-fetch";
 
-const pickleApi = "https://stkpowy01i.execute-api.us-west-1.amazonaws.com/prod/";
+const pickleApi = "https://stkpowy01i.execute-api.us-west-1.amazonaws.com/prod";
 
 export const getJarChart = async (assets) => {
   const jarData = assets.map(async (asset) => {


### PR DESCRIPTION
There's currently an extra forward slash in the API routes but... it still somehow works 😅

<img width="755" alt="Screen Shot 2021-05-23 at 00 34 59" src="https://user-images.githubusercontent.com/7811733/119235890-d7656b00-bb5e-11eb-955a-5cc4839b3708.png">
