### PR TITLE
Show user share of total DILL as a tooltip

### DIFF
--- a/components/PickleIcon.tsx
+++ b/components/PickleIcon.tsx
@@ -1,0 +1,20 @@
+import { FC } from "react";
+
+interface Props {
+  size: number;
+  margin?: number | string;
+}
+
+const PickleIcon: FC<Props> = ({ size, margin = 0 }) => (
+  <img
+    src="/pickle.png"
+    alt="pickle"
+    style={{
+      width: size,
+      margin,
+      verticalAlign: `text-bottom`,
+    }}
+  />
+);
+
+export default PickleIcon;

--- a/features/Balances/Balances.tsx
+++ b/features/Balances/Balances.tsx
@@ -9,6 +9,7 @@ import { Jars } from "../../containers/Jars";
 import { PickleStaking } from "../../containers/PickleStaking";
 import { Prices as PriceComponent } from "../Prices/Prices";
 import { ethers } from "ethers";
+import PickleIcon from "../../components/PickleIcon";
 
 const Container = styled(Grid.Container)`
   font-family: "Source Code Pro", sans-serif;
@@ -25,18 +26,6 @@ const HideOnMobile = styled.div`
     display: none;
   }
 `;
-
-const PickleIcon = ({ size = "24px", margin = "0 0 0 0.5rem" }) => (
-  <img
-    src="/pickle.png"
-    alt="pickle"
-    style={{
-      width: size,
-      margin,
-      verticalAlign: `text-bottom`,
-    }}
-  />
-);
 
 const formatPickles = (num: number) =>
   num.toLocaleString(undefined, {
@@ -108,7 +97,7 @@ export const Balances: FC = () => {
               <span>
                 {pickleBalance !== null ? formatPickles(pickleBalance) : "--"}
               </span>
-              <PickleIcon />
+              <PickleIcon size={24} margin="0 0 0 0.5rem" />
               {pickleBalance !== null && prices?.pickle && (
                 <HideOnMobile>
                   <span style={{ fontSize: `1rem` }}>
@@ -122,7 +111,7 @@ export const Balances: FC = () => {
               Pending:&nbsp;
               <span>
                 {pendingPickles !== null ? formatPickles(pendingPickles) : "--"}
-                <PickleIcon size="14px" />
+                <PickleIcon size={14} margin="0 0 0 0.5rem" />
               </span>
               {pendingPickles !== null && prices?.pickle && (
                 <HideOnMobile>
@@ -159,12 +148,12 @@ export const Balances: FC = () => {
                 >
                   Total Supply:{" "}
                   {totalSupply ? formatPickles(totalSupply) : "--"}
-                  <PickleIcon size="14px" />
+                  <PickleIcon size={14} margin="0 0 0 0.5rem" />
                 </Tooltip>
               ) : (
                 <span>
                   Total Supply: --
-                  <PickleIcon size="14px" />
+                  <PickleIcon size={14} margin="0 0 0 0.5rem" />
                 </span>
               )}
             </Card.Footer>

--- a/features/DILL/Balances.tsx
+++ b/features/DILL/Balances.tsx
@@ -4,8 +4,9 @@ import styled from "styled-components";
 import { formatEther } from "ethers/lib/utils";
 
 import { useBalances } from "../Balances/useBalances";
-import { Dill, UseDillOutput } from "../../containers/Dill";
-import { formatDate } from "../../util/date";
+import { DillStats } from "./DillStats";
+import { UseDillOutput } from "../../containers/Dill";
+import PickleIcon from "../../components/PickleIcon";
 
 const DataPoint = styled.div`
   font-size: 22px;
@@ -13,28 +14,10 @@ const DataPoint = styled.div`
   align-items: center;
 `;
 
-const PickleIcon = ({ size = "24px", margin = "0 0 0 0.5rem" }) => (
-  <img
-    src="/pickle.png"
-    alt="pickle"
-    style={{
-      width: size,
-      margin,
-      verticalAlign: `text-bottom`,
-    }}
-  />
-);
-
 export const Balances: FC<{
   dillStats: UseDillOutput;
 }> = ({ dillStats }) => {
   const { pickleBalance } = useBalances();
-  const { balance: dillBalance } = Dill.useContainer();
-
-  const unlockTime = new Date();
-  unlockTime.setTime(+(dillStats.lockEndDate?.toString() || 0) * 1000);
-  const isLocked = Boolean(+(dillStats.lockEndDate?.toString() || 0));
-  const isExpired = unlockTime < new Date();
 
   return (
     <Grid.Container gap={2}>
@@ -50,49 +33,12 @@ export const Balances: FC<{
                   })
                 : "--"}
             </span>
-            <PickleIcon />
+            <PickleIcon size={24} margin="0 0 0 0.5rem" />
           </DataPoint>
         </Card>
       </Grid>
       <Grid xs={24} sm={10} md={10}>
-        <Card>
-          <h2>
-            {isLocked ? (
-              isExpired ? (
-                <>Expired (since {formatDate(unlockTime)})</>
-              ) : (
-                <>Locked (until {formatDate(unlockTime)})</>
-              )
-            ) : (
-              "Unlocked"
-            )}
-          </h2>
-          <DataPoint>
-            <span>
-              {dillStats.lockedAmount !== null
-                ? Number(
-                    formatEther(dillStats.lockedAmount?.toString() || "0"),
-                  ).toLocaleString(undefined, {
-                    minimumFractionDigits: 0,
-                    maximumFractionDigits: 2,
-                  })
-                : "--"}
-            </span>
-            <PickleIcon />
-            &nbsp;=&nbsp;
-            <span>
-              {pickleBalance !== null
-                ? Number(
-                    formatEther(dillBalance?.toString() || "0"),
-                  ).toLocaleString(undefined, {
-                    minimumFractionDigits: 0,
-                    maximumFractionDigits: 2,
-                  })
-                : "--"}
-            </span>
-            &nbsp;DILL
-          </DataPoint>
-        </Card>
+        <DillStats dillStats={dillStats} pickleBalance={pickleBalance} />
       </Grid>
       <Grid xs={24} sm={9} md={9}>
         <Card>
@@ -108,10 +54,11 @@ export const Balances: FC<{
                   })
                 : "--"}
             </span>
-            <PickleIcon />
+            <PickleIcon size={24} margin="0 0 0 0.5rem" />
             &nbsp;=&nbsp;
             <span>
-              ${pickleBalance !== null
+              $
+              {pickleBalance !== null
                 ? Number(
                     dillStats.totalPickleValue?.toString() || "0",
                   ).toLocaleString(undefined, {

--- a/features/DILL/Claim.tsx
+++ b/features/DILL/Claim.tsx
@@ -1,14 +1,15 @@
 import { useState, FC, useEffect } from "react";
 import { Spacer, Grid, Card, Button } from "@geist-ui/react";
-import styled from "styled-components";
 import { formatEther } from "ethers/lib/utils";
 import { Contracts } from "../../containers/Contracts";
 import { Connection } from "../../containers/Connection";
-import { Dill, UseDillOutput } from "../../containers/Dill";
+import { UseDillOutput } from "../../containers/Dill";
 import {
   ERC20Transfer,
   Status as ERC20TransferStatus,
 } from "../../containers/Erc20Transfer";
+import { formatPercent } from "../../util/number";
+import PickleIcon from "../../components/PickleIcon";
 
 interface ButtonStatus {
   disabled: boolean;
@@ -47,24 +48,6 @@ const formatNumber = (num: number, precision?: number) =>
     maximumFractionDigits: precision || 2,
   }) ||
     0);
-
-const formatPercent = (decimal: number) =>
-  decimal &&
-  (decimal * 100).toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }) + "%";
-
-const PickleIcon = ({ size = "16px" }) => (
-  <img
-    src="/pickle.png"
-    alt="pickle"
-    style={{
-      width: size,
-      verticalAlign: `text-bottom`,
-    }}
-  />
-);
 
 export const Claim: FC<{
   dillStats: UseDillOutput;
@@ -139,7 +122,8 @@ export const Claim: FC<{
             <div>
               Last week's distribution: $
               {formatNumber(dillStats?.lastDistributionValue)} (
-              {formatNumber(dillStats?.lastDistribution)} <PickleIcon />)
+              {formatNumber(dillStats?.lastDistribution)}{" "}
+              <PickleIcon size={16} />)
             </div>
             &nbsp;
             <Spacer />

--- a/features/DILL/DillStats.tsx
+++ b/features/DILL/DillStats.tsx
@@ -1,0 +1,79 @@
+import { FC } from "react";
+import { Card, Tooltip } from "@geist-ui/react";
+import styled from "styled-components";
+import { formatEther } from "ethers/lib/utils";
+
+import { UseDillOutput } from "../../containers/Dill";
+import { formatDate } from "../../util/date";
+import { formatPercent } from "../../util/number";
+import PickleIcon from "../../components/PickleIcon";
+
+const DataPoint = styled.div`
+  font-size: 22px;
+  display: flex;
+  align-items: center;
+`;
+
+const formatNumber = (value: number, min = 0, max = 2) =>
+  value.toLocaleString(undefined, {
+    minimumFractionDigits: min,
+    maximumFractionDigits: max,
+  });
+
+interface Props {
+  pickleBalance: number | null;
+  dillStats: UseDillOutput;
+}
+
+export const DillStats: FC<Props> = ({ pickleBalance, dillStats }) => {
+  const {
+    totalSupply: dillSupply,
+    lockEndDate,
+    lockedAmount,
+    balance: dillBalance,
+  } = dillStats;
+
+  const unlockTime = new Date();
+  unlockTime.setTime(+(lockEndDate?.toString() || 0) * 1000);
+  const isLocked = Boolean(+(lockEndDate?.toString() || 0));
+  const isExpired = unlockTime < new Date();
+
+  const isFetchingData = pickleBalance === null || !dillBalance;
+
+  const lockedAmountValue = Number(
+    formatEther(lockedAmount?.toString() || "0"),
+  );
+  const dillBalanceValue = Number(formatEther(dillBalance?.toString() || "0"));
+  const ratio = dillSupply
+    ? dillBalanceValue / parseFloat(formatEther(dillSupply))
+    : 0;
+
+  return (
+    <Card>
+      <h2>
+        {isLocked ? (
+          isExpired ? (
+            <>Expired (since {formatDate(unlockTime)})</>
+          ) : (
+            <>Locked (until {formatDate(unlockTime)})</>
+          )
+        ) : (
+          "Unlocked"
+        )}
+      </h2>
+      <DataPoint>
+        <span>{isFetchingData ? "--" : formatNumber(lockedAmountValue)}</span>
+        <PickleIcon size={24} margin="0 0 0 0.5rem" />
+        &nbsp;=&nbsp;
+        <Tooltip
+          placement="bottom"
+          style={{ cursor: "help" }}
+          text={`${formatPercent(ratio, 1, 5)} of total DILL`}
+        >
+          <span>{isFetchingData ? "--" : formatNumber(dillBalanceValue)}</span>
+          &nbsp;DILL
+        </Tooltip>
+      </DataPoint>
+    </Card>
+  );
+};

--- a/features/DILL/DillStats.tsx
+++ b/features/DILL/DillStats.tsx
@@ -11,6 +11,7 @@ import PickleIcon from "../../components/PickleIcon";
 const DataPoint = styled.div`
   font-size: 22px;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
 `;
 
@@ -62,17 +63,24 @@ export const DillStats: FC<Props> = ({ pickleBalance, dillStats }) => {
         )}
       </h2>
       <DataPoint>
-        <span>{isFetchingData ? "--" : formatNumber(lockedAmountValue)}</span>
-        <PickleIcon size={24} margin="0 0 0 0.5rem" />
-        &nbsp;=&nbsp;
-        <Tooltip
-          placement="bottom"
-          style={{ cursor: "help" }}
-          text={`${formatPercent(ratio, 1, 5)} of total DILL`}
-        >
-          <span>{isFetchingData ? "--" : formatNumber(dillBalanceValue)}</span>
-          &nbsp;DILL
-        </Tooltip>
+        <div>
+          <span>{isFetchingData ? "--" : formatNumber(lockedAmountValue)}</span>
+          <PickleIcon size={24} margin="0 0 0 0.5rem" />
+          &nbsp;=&nbsp;
+        </div>
+        <div>
+          <Tooltip
+            placement="bottom"
+            style={{ cursor: "help" }}
+            text={`${formatPercent(ratio, 1, 5)} of total DILL`}
+          >
+            <span>
+              {isFetchingData ? "--" : formatNumber(dillBalanceValue)}
+            </span>
+            &nbsp;DILL
+            <img src="./question.svg" style={{ marginLeft: 8, width: 15 }} />
+          </Tooltip>
+        </div>
       </DataPoint>
     </Card>
   );

--- a/features/Stake/Balances.tsx
+++ b/features/Stake/Balances.tsx
@@ -5,24 +5,13 @@ import { formatEther } from "ethers/lib/utils";
 
 import { UseStakingRewardsOutput } from "../../containers/Staking/useStakingRewards";
 import { useBalances } from "../Balances/useBalances";
+import PickleIcon from "../../components/PickleIcon";
 
 const DataPoint = styled.div`
   font-size: 24px;
   display: flex;
   align-items: center;
 `;
-
-const PickleIcon = ({ size = "24px", margin = "0 0 0 0.5rem" }) => (
-  <img
-    src="/pickle.png"
-    alt="pickle"
-    style={{
-      width: size,
-      margin,
-      verticalAlign: `text-bottom`,
-    }}
-  />
-);
 
 const CRVIcon = ({ size = "24px", margin = "0 0 0 0.5rem" }) => (
   <img
@@ -99,7 +88,7 @@ export const Balances: FC<{
                   })
                 : "--"}
             </span>
-            <PickleIcon />
+            <PickleIcon size={24} margin="0 0 0 0.5rem" />
           </DataPoint>
         </Card>
       </Grid>

--- a/util/number.ts
+++ b/util/number.ts
@@ -1,2 +1,8 @@
 export const roundNumber = (number: number, digits: number) =>
   Math.round(number * Math.pow(10, digits)) / Math.pow(10, digits);
+
+export const formatPercent = (decimal: number, min = 2, max = 2) =>
+  (decimal * 100).toLocaleString(undefined, {
+    minimumFractionDigits: min,
+    maximumFractionDigits: max,
+  }) + "%";


### PR DESCRIPTION
Suggested on [Discord](https://discord.com/channels/750784472697405646/756691672414421156/848792767797657630) and [Forum](https://feedback.pickle.finance/features/p/show-of-dill-owned-relative-to-total).

<img width="413" alt="Screen Shot 2021-05-31 at 22 31 37" src="https://user-images.githubusercontent.com/7811733/120215623-25195c00-c260-11eb-8f99-f9a1b704c31b.png">

Added `flex-wrap` to accomodate larger balances:

<img width="445" alt="Screen Shot 2021-05-31 at 22 30 36" src="https://user-images.githubusercontent.com/7811733/120215634-277bb600-c260-11eb-8e28-f41c9064ef7d.png">
 


Thought this was a great idea!
