### PR TITLE
Fix connector item icon paths

### DIFF
--- a/features/Connection/Web3Modal/ConnectorItem.tsx
+++ b/features/Connection/Web3Modal/ConnectorItem.tsx
@@ -63,7 +63,7 @@ const ConnectorItem: FC<ConnectorItemProps> = ({
           <Loader type="TailSpin" color="#aaa" height={50} width={50} />
         </LoaderContainer>
       )}
-      <img src={`wallet/${icon}`} width="30px" alt="wallet" />
+      <img src={`/wallet/${icon}`} width="30px" alt="wallet" />
       {title}
     </StyledContainer>
   );


### PR DESCRIPTION
The images are broken if you try to connect a wallet from a nested route, such as https://app.pickle.finance/info/earn because the paths are relative.

<img width="545" alt="Screen Shot 2021-05-31 at 22 45 34" src="https://user-images.githubusercontent.com/7811733/120217129-1b90f380-c262-11eb-8d85-0c7d0bdf5bdc.png">