### PR TITLE
Add net weekly DILL chart series

### DIFF
--- a/containers/DILL/useFeeDistributionSeries.ts
+++ b/containers/DILL/useFeeDistributionSeries.ts
@@ -15,7 +15,8 @@ const firstMeaningfulDistributionTimestamp = 1619049600;
 export type FeeDistributionDataPoint = {
   weeklyPickleAmount: number;
   totalPickleAmount: number;
-  dillAmount: number;
+  weeklyDillAmount: number;
+  totalDillAmount: number;
   pickleDillRatio: number;
   isProjected: boolean;
   picklePriceUsd: number;
@@ -74,6 +75,7 @@ export function useFeeDistributionSeries() {
       });
 
       let totalPickleAmount = 0;
+      let lastTotalDillAmount = 0;
 
       setFeeDistributionSeries(
         payoutTimes.map((time, index) => {
@@ -92,16 +94,21 @@ export function useFeeDistributionSeries() {
             ? historicalEntry[1]
             : prices.pickle;
 
-          const dillAmount = parseFloat(
+          const totalDillAmount = parseFloat(
             ethers.utils.formatEther(dillAmounts[index]),
           );
-          const pickleDillRatio = weeklyPickleAmount / dillAmount;
+          const pickleDillRatio = weeklyPickleAmount / totalDillAmount;
+
           totalPickleAmount += weeklyPickleAmount;
+
+          const weeklyDillAmount = totalDillAmount - lastTotalDillAmount;
+          lastTotalDillAmount = totalDillAmount;
 
           return {
             weeklyPickleAmount,
             totalPickleAmount,
-            dillAmount,
+            weeklyDillAmount,
+            totalDillAmount,
             pickleDillRatio,
             picklePriceUsd,
             isProjected,

--- a/features/DILL/FeeDistributionsChart.tsx
+++ b/features/DILL/FeeDistributionsChart.tsx
@@ -62,8 +62,10 @@ const tooltipFormatter = (
       return [formattedDollarValue, "Weekly PICKLEs"];
     case "totalPickleAmount":
       return [formattedDollarValue, "Total PICKLEs"];
-    case "dillAmount":
-      return [formattedNumber, "DILL amount"];
+    case "weeklyDillAmount":
+      return [formattedNumber, "Weekly DILL amount"];
+    case "totalDillAmount":
+      return [formattedNumber, "Total DILL amount"];
     case "pickleDillRatio":
       return [
         `${formattedNumber} (${formatDollarValue(amount, 2)})`,
@@ -79,8 +81,10 @@ const legendFormatter = (value: string): string => {
       return "Weekly PICKLEs";
     case "totalPickleAmount":
       return "Total PICKLEs";
-    case "dillAmount":
-      return "DILL amount";
+    case "weeklyDillAmount":
+      return "Weekly DILL amount";
+    case "totalDillAmount":
+      return "Total DILL amount";
     case "pickleDillRatio":
       return "Distributed PICKLEs per 1 DILL";
     default:
@@ -187,7 +191,14 @@ export const FeeDistributionsChart: FC = () => {
                   />
                 ))}
               </Bar>
-              <Bar dataKey="dillAmount" fill="#ebebeb">
+              <Bar
+                dataKey={
+                  chartMode === "weekly"
+                    ? "weeklyDillAmount"
+                    : "totalDillAmount"
+                }
+                fill="#ebebeb"
+              >
                 {dataSeries.map((point, index) => (
                   <Cell
                     fill="#ebebeb"

--- a/features/DILL/FeeDistributionsChart.tsx
+++ b/features/DILL/FeeDistributionsChart.tsx
@@ -59,13 +59,13 @@ const tooltipFormatter = (
 
   switch (name) {
     case "weeklyPickleAmount":
-      return [formattedDollarValue, "Weekly PICKLEs"];
+      return [formattedDollarValue, "Weekly PICKLEs distributed"];
     case "totalPickleAmount":
-      return [formattedDollarValue, "Total PICKLEs"];
+      return [formattedDollarValue, "Total PICKLEs distributed"];
     case "weeklyDillAmount":
-      return [formattedNumber, "Weekly DILL amount"];
+      return [formattedNumber, "Weekly DILL 🔒"];
     case "totalDillAmount":
-      return [formattedNumber, "Total DILL amount"];
+      return [formattedNumber, "Total DILL 🔒"];
     case "pickleDillRatio":
       return [
         `${formattedNumber} (${formatDollarValue(amount, 2)})`,


### PR DESCRIPTION
This changes the DILL series when set to weekly as suggested [here](https://feedback.pickle.finance/features/p/improve-total-dill-outstanding-on-ui). This way we can see net week-to-week changes in DILL supply and toggle consistently between weekly and total amounts for both DILL and PICKLE.

![demo](http://g.recordit.co/AuxlNZ4TZY.gif)