### PR TITLE
Fixes #56 - use new jarApy api from pools endpoint

### DIFF
--- a/containers/DILL/useProtocolIncome.ts
+++ b/containers/DILL/useProtocolIncome.ts
@@ -19,20 +19,10 @@ export function useProtocolIncome() {
       "https://stkpowy01i.execute-api.us-west-1.amazonaws.com/prod/protocol/pools",
     ).then<Jar[]>((response) => response.json());
 
-    const jarPerformance: Jar[] = await Promise.all(
-      jarList.map(async (jar) => {
-        const apy = await getAssetPerformanceData(jar.identifier);
-        return {
-          ...jar,
-          apy: apy.threeDay,
-        };
-      }),
-    );
-
-    const profit = jarPerformance.reduce((acc, currJar) => {
+    const profit = jarList.reduce((acc, currJar) => {
       const jarTVL = currJar.liquidity_locked;
-      return +currJar.apy > 0
-        ? acc + (jarTVL * currJar.apy * 0.01 * 0.2) / 52
+      return +currJar.jarApy > 0
+        ? acc + (jarTVL * currJar.jarApy * 0.01 * 0.2) / 52
         : acc;
     }, 0);
 


### PR DESCRIPTION
Signed-off-by: Rob Stryker <rob@oxbeef.net>

Using the build system to test. Yes, I'm not organized enough ;) 