### PR TITLE
Fix frontpage zap widget crash

### DIFF
--- a/features/Zap/DepositZap.tsx
+++ b/features/Zap/DepositZap.tsx
@@ -75,7 +75,9 @@ export const DepositZap: FC = () => {
     if (txState !== null) return true;
     if (amount === "0") return true;
     if (amount === "") return true;
-    if (balanceStr && parseFloat(amount) > parseFloat(balanceStr)) return true;
+    const parsedAmount = parseFloat(amount);
+    if (balanceStr && parsedAmount > parseFloat(balanceStr)) return true;
+    if (parsedAmount < 0) return true;
     return false;
   };
 

--- a/features/Zap/DepositZap.tsx
+++ b/features/Zap/DepositZap.tsx
@@ -23,7 +23,7 @@ const formatValue = (numStr: string) =>
 export const DepositZap: FC = () => {
   const [inputToken, setInputToken] = useState<TokenSymbol>("ETH");
   const [sellTokenAddress, setSellTokenAddress] = useState(ETH_ADDRESS);
-  const [amount, setAmount] = useState<string>("0");
+  const [amount, setAmount] = useState<string>("");
   const [txState, setTxState] = useState<string | null>(null);
 
   const { balanceStr, decimals } = useBalance(inputToken);
@@ -129,6 +129,7 @@ export const DepositZap: FC = () => {
         </DisplayLink>
       </div>
       <Input
+        placeholder="0"
         onChange={(e) => setAmount(e.target.value)}
         value={amount}
         width="100%"

--- a/features/Zap/useZapper.tsx
+++ b/features/Zap/useZapper.tsx
@@ -43,7 +43,7 @@ export const useZapIn = ({
 }: ZapperData) => {
   const { address, signer } = Connection.useContainer();
   const isSellTokenEth = isEth(sellTokenAddress);
-  const sellAmount = parseUnits(rawAmount, 18).toString();
+  const sellAmount = rawAmount ? parseUnits(rawAmount, 18).toString() : '0';
 
   const zapIn = async () => {
     try {


### PR DESCRIPTION
Right now if you go to the front page and remove the default "0" in the zap input, the application crashes.

The input will also allow you to attempt a transaction with a negative amount, and even send that transaction that to your wallet app.

This PR fixes those issues.

Additionally, I've removed the "0" default on this input and replaced it with an HTML "placeholder" value so the user doesn't need to backspace at all to enter an amount. Using a placeholder in this manner is pretty common behavior among payment applications.