### PR TITLE
filter zero balance from earnings column

### DIFF
--- a/pages/info/earn.js
+++ b/pages/info/earn.js
@@ -206,7 +206,7 @@ export default function Earn(props) {
   let earnRows;
   if (accountData) {
     earnRows = accountData.jarData
-      .filter((jar) => jar.earnedUsd > 0)
+      .filter((jar) => jar.earnedUsd > 0 && jar.balance > 0)
       .map((jar, i) => {
         const jarInfo = jars.find((s) => s.asset === jar.asset.toLowerCase());
         return (


### PR DESCRIPTION
small fix to remove jars where a user no longer as any balance.  the api still returns a value, but with `balance === 0`

otherwise, the rows no longer align properly