### PR TITLE
Cached API routes/serverless function responses

### DIFF
--- a/containers/Jars/useUniPairDayData.ts
+++ b/containers/Jars/useUniPairDayData.ts
@@ -1,85 +1,35 @@
 import { useEffect, useState } from "react";
-
-import { Connection } from "../Connection";
-import { JAR_DEPOSIT_TOKENS } from "./jars";
-import { PICKLE_ETH_FARM } from "../Farms/farms";
-import { NETWORK_NAMES } from "containers/config"
-
-export interface UniLPAPY {
-  pairAddress: string;
-  reserveUSD: number;
-  dailyVolumeUSD: number;
-}
-
-const UNI_LP_TOKENS = [
-  PICKLE_ETH_FARM,
-  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_ETH_DAI,
-  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_ETH_USDC,
-  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_ETH_USDT,
-  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_ETH_WBTC,
-  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_MIR_UST,
-  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_MTSLA_UST,
-  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_MAAPL_UST,
-  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_MQQQ_UST,
-  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_MSLV_UST,
-  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_MBABA_UST,
-  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_FEI_TRIBE,
-  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_LUSD_ETH,
-];
+import { Record, Response } from "pages/api/uniswap-v2";
 
 export const useUniPairDayData = () => {
-  const { signer } = Connection.useContainer();
-
-  const [uniPairDayData, setUniPairDayData] = useState<Array<UniLPAPY> | null>(
-    null,
-  );
+  const [uniPairDayData, setUniPairDayData] = useState<Record[]>([]);
 
   const queryTheGraph = async () => {
-    const res = await fetch(
-      "https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2",
-      {
-        credentials: "omit",
-        headers: {
-          "User-Agent":
-            "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:81.0) Gecko/20100101 Firefox/81.0",
-          Accept: "*/*",
-          "Accept-Language": "en-US,en;q=0.5",
-          "Content-Type": "application/json",
-        },
-        referrer: "https://thegraph.com/explorer/subgraph/uniswap/uniswap-v2",
-        body: `{"query":"{\\n  pairDayDatas(first: ${UNI_LP_TOKENS.length.toString()}, skip: 1, orderBy: date, orderDirection: desc, where: {pairAddress_in: [\\"${UNI_LP_TOKENS.join(
-          '\\", \\"',
-        )}\\"]}) {\\n    pairAddress\\n    reserveUSD\\n    dailyVolumeUSD\\n  }\\n}\\n","variables":null}`,
-        method: "POST",
-        mode: "cors",
-      },
-    ).then((x) => x.json());
+    const res: Response = await fetch("/api/uniswap-v2").then((x) => x.json());
 
     res?.data?.pairDayDatas && setUniPairDayData(res?.data?.pairDayDatas); // Sometimes the graph call fails
   };
 
   const getUniPairDayAPY = (pair: string) => {
-    if (uniPairDayData) {
-      const filteredPair = uniPairDayData.filter(
-        (x) => x.pairAddress.toLowerCase() === pair.toLowerCase(),
-      );
+    const filteredPair = uniPairDayData.filter(
+      (x) => x.pairAddress.toLowerCase() === pair.toLowerCase(),
+    );
 
-      if (filteredPair.length > 0) {
-        const selected = filteredPair[0];
+    if (filteredPair.length > 0) {
+      const selected = filteredPair[0];
 
-        // 0.3% fee to LP
-        const apy =
-          (selected.dailyVolumeUSD / selected.reserveUSD) * 0.003 * 365 * 100;
+      // 0.3% fee to LP
+      const apy =
+        (selected.dailyVolumeUSD / selected.reserveUSD) * 0.003 * 365 * 100;
 
-        return [{ lp: apy }];
-      }
+      return [{ lp: apy }];
     }
 
     return [];
   };
 
   useEffect(() => {
-    if(!uniPairDayData) queryTheGraph();
+    queryTheGraph();
   }, []);
 
   return {

--- a/pages/api/uniswap-v2.ts
+++ b/pages/api/uniswap-v2.ts
@@ -1,0 +1,81 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { JAR_DEPOSIT_TOKENS } from "../../containers/Jars/jars";
+import { PICKLE_ETH_FARM } from "../../containers/Farms/farms";
+import { NETWORK_NAMES } from "containers/config";
+
+export interface Record {
+  pairAddress: string;
+  reserveUSD: number;
+  dailyVolumeUSD: number;
+}
+
+export interface Response {
+  data: {
+    pairDayDatas: Record[];
+  };
+}
+
+const UNI_LP_TOKENS = [
+  PICKLE_ETH_FARM,
+  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_ETH_DAI,
+  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_ETH_USDC,
+  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_ETH_USDT,
+  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_ETH_WBTC,
+  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_MIR_UST,
+  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_MTSLA_UST,
+  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_MAAPL_UST,
+  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_MQQQ_UST,
+  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_MSLV_UST,
+  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_MBABA_UST,
+  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_FEI_TRIBE,
+  JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].UNIV2_LUSD_ETH,
+];
+
+const fetchData = async () => {
+  const query = `
+  {
+    pairDayDatas(
+      first: ${UNI_LP_TOKENS.length}
+      skip: 1
+      orderBy: date
+      orderDirection: desc
+      where: {
+        pairAddress_in: [
+          ${UNI_LP_TOKENS.map((address) => `"${address}"`).join(", ")}
+        ]
+      }
+    ) {
+      pairAddress
+      reserveUSD
+      dailyVolumeUSD
+    }
+  }
+  `;
+
+  const res = await fetch(
+    "https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2",
+    {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      referrer: "https://thegraph.com/explorer/subgraph/uniswap/uniswap-v2",
+      body: JSON.stringify({ query }),
+      method: "POST",
+      mode: "cors",
+    },
+  );
+
+  return await res.json();
+};
+
+export default async (_req: NextApiRequest, res: NextApiResponse) => {
+  const data: Response = await fetchData();
+
+  /**
+   * Cache for 5 seconds, then revalidate _in the background_ if requested within
+   * the consecutive 55 seconds.
+   */
+  res.setHeader("Cache-Control", "s-maxage=5, stale-while-revalidate=55");
+  res.status(200).json(data);
+};


### PR DESCRIPTION
This introduces an API route/serverless function as a PoC of caching slow endpoints that don't need to be 100% up-to-date. For example, we can cache queries to The Graph to make them return instantly with the tradeoff of having data that is a few seconds stale.

<img width="1798" alt="vercel" src="https://user-images.githubusercontent.com/7811733/124007568-ac93ef80-da05-11eb-8e77-a2d3ed814556.png">


[Docs.](https://vercel.com/docs/edge-network/caching#stale-while-revalidate)