### PR TITLE
Use CloudFront CDN

### DIFF
--- a/util/api.js
+++ b/util/api.js
@@ -1,6 +1,6 @@
 import fetch from "node-fetch";
 
-const pickleApi = "https://stkpowy01i.execute-api.us-west-1.amazonaws.com/prod";
+const pickleApi = "https://duvqzd67em13i.cloudfront.net/brining";
 
 export const getJarChart = async (assets) => {
   const jarData = assets.map(async (asset) => {


### PR DESCRIPTION
This uses my own serverless distribution with the config from https://github.com/pickle-finance/pickle-api/pull/11

All API endpoints return in 200-300ms 🚀 Besides being faster, I'd expect using CDN in front of API Gateway to be _way_ cheaper but we'll need to see if that's the case. More details in the API PR.