### PR TITLE
Fix farms performance

### DIFF
--- a/containers/Farms/useJarFarmApy.ts
+++ b/containers/Farms/useJarFarmApy.ts
@@ -11,7 +11,6 @@ import { FarmWithReward } from "./useWithReward";
 import { Jars } from "../Jars";
 
 import mlErc20 from "@studydefi/money-legos/erc20";
-import { NETWORK_NAMES } from "containers/config";
 import { Contract as MulticallContract } from "ethers-multicall";
 
 // what comes in and goes out of this function
@@ -21,7 +20,7 @@ type Output = { jarFarmWithApy: FarmWithApy[] | null };
 export const useJarFarmApy = (inputFarms: Input): Output => {
   const { jars } = Jars.useContainer();
   const { masterchef } = Contracts.useContainer();
-  const { multicallProvider, chainName } = Connection.useContainer();
+  const { multicallProvider } = Connection.useContainer();
 
   const [farms, setFarms] = useState<FarmWithApy[] | null>(null);
 

--- a/containers/Gauges.ts
+++ b/containers/Gauges.ts
@@ -6,10 +6,6 @@ import { useUniV2Apy } from "./Gauges/useUniV2Apy";
 import { useJarGaugeApy } from "./Gauges/useJarGaugeApy";
 import { FarmInfo } from "./Farms";
 
-interface IGaugeInfo {
-  [key: string]: { tokenName: string; poolName: string };
-}
-
 export const GaugeInfo = FarmInfo;
 
 function useGauges() {

--- a/containers/Gauges/useFetchGauges.ts
+++ b/containers/Gauges/useFetchGauges.ts
@@ -1,8 +1,7 @@
-import { Contract } from "@ethersproject/contracts";
 import { useState, useEffect } from "react";
 
 import { Connection } from "../Connection";
-import { Contracts, GAUGE_PROXY } from "../Contracts";
+import { Contracts } from "../Contracts";
 import { Contract as MulticallContract } from "ethers-multicall";
 
 export interface RawGauge {
@@ -16,12 +15,7 @@ export interface RawGauge {
 }
 
 export const useFetchGauges = (): { rawGauges: Array<RawGauge> | null } => {
-  const {
-    blockNum,
-    multicallProvider,
-    chainName,
-    provider,
-  } = Connection.useContainer();
+  const { blockNum, multicallProvider, chainName } = Connection.useContainer();
   const { gaugeProxy, gauge } = Contracts.useContainer();
 
   const [gauges, setGauges] = useState<Array<RawGauge> | null>(null);
@@ -96,7 +90,7 @@ export const useFetchGauges = (): { rawGauges: Array<RawGauge> | null } => {
 
   useEffect(() => {
     getGauges();
-  }, [blockNum]);
+  }, [gaugeProxy, multicallProvider, blockNum]);
 
   return { rawGauges: gauges };
 };

--- a/containers/Gauges/useWithReward.ts
+++ b/containers/Gauges/useWithReward.ts
@@ -19,7 +19,7 @@ export const useWithReward = (rawGauges: Input): Output => {
   const [gauges, setGauges] = useState<Array<GaugeWithReward> | null>(null);
 
   const calculateReward = () => {
-    if (rawGauges?.length && picklePerBlock && prices) {
+    if (rawGauges && picklePerBlock && prices) {
       // do calculations for each gauge
       const newGauges = rawGauges.map((gauge) => {
         return {

--- a/containers/Jars.ts
+++ b/containers/Jars.ts
@@ -9,7 +9,6 @@ import { useJarWithAPY as useJarsWithAPYPoly } from "./Jars/useJarsWithAPYPoly";
 import { useJarWithTVL } from "./Jars/useJarsWithTVL";
 import { BPAddresses } from "./config";
 import { PICKLE_ETH_SLP } from "./Contracts";
-
 import { NETWORK_NAMES } from "./config";
 
 function useJars() {

--- a/containers/Jars/useJarsWithAPYEth.ts
+++ b/containers/Jars/useJarsWithAPYEth.ts
@@ -1003,7 +1003,7 @@ export const useJarWithAPY = (network: ChainName, jars: Input): Output => {
 
   useEffect(() => {
     if (network === NETWORK_NAMES.ETH) calculateAPY();
-  }, [jars, prices, network]);
+  }, [jars?.length, prices, network]);
 
   return { jarsWithAPY };
 };

--- a/containers/Jars/useJarsWithTVL.ts
+++ b/containers/Jars/useJarsWithTVL.ts
@@ -15,7 +15,7 @@ type Output = {
   jarsWithTVL: Array<JarWithTVL> | null;
 };
 
-const isMStonksJar = (token) =>
+const isMStonksJar = (token: string) =>
   token === PICKLE_JARS.pUNIMTSLAUST.toLowerCase() ||
   token === PICKLE_JARS.pUNIMBABAUST.toLowerCase() ||
   token === PICKLE_JARS.pUNIMSLVUST.toLowerCase() ||
@@ -52,7 +52,7 @@ export const useJarWithTVL = (jars: Input): Output => {
 
   useEffect(() => {
     measureTVL();
-  }, [jars]);
+  }, [jars?.length, poolData.length]);
 
   return {
     jarsWithTVL,

--- a/containers/Jars/usePoolData.ts
+++ b/containers/Jars/usePoolData.ts
@@ -2,8 +2,21 @@ import { createContainer } from "unstated-next";
 import { useEffect, useState } from "react";
 import { getPoolData } from "../../util/api.js";
 
+interface Pool {
+  apy: number;
+  gaugeAddress: string;
+  identifier: string;
+  jarAddress: string;
+  jarApy: number;
+  liquidity_locked: number;
+  network: string;
+  ratio: number;
+  tokenAddress: string;
+  tokens: number;
+}
+
 const usePoolData = () => {
-  const [poolData, setPoolData] = useState();
+  const [poolData, setPoolData] = useState<Pool[]>([]);
   const fetchPoolData = async () => setPoolData(await getPoolData());
 
   useEffect(() => {

--- a/containers/MiniFarms.ts
+++ b/containers/MiniFarms.ts
@@ -1,7 +1,6 @@
 import { createContainer } from "unstated-next";
 
 import { useWithReward } from "./MiniFarms/useWithReward";
-import { useUniV2Apy } from "./Farms/useUniV2Apy";
 import { useJarFarmApy } from "./Farms/useJarFarmApy";
 import { useFetchFarms } from "./Farms/useFetchFarms";
 import { useMaticJarApy } from "./MiniFarms/useMaticJarApy";
@@ -70,6 +69,7 @@ function useFarms() {
   const { farmsWithReward } = useWithReward(rawFarms);
   const { jarFarmWithApy } = useJarFarmApy(farmsWithReward);
   const { jarFarmWithMaticApy } = useMaticJarApy(jarFarmWithApy);
+
   const jarFarms = jarFarmWithMaticApy
     ?.map((farm) => {
       if (!FarmInfo[farm.lpToken]) return null;

--- a/containers/Pickles/usePicklePerBlock.ts
+++ b/containers/Pickles/usePicklePerBlock.ts
@@ -4,12 +4,12 @@ import { Connection } from "../Connection";
 import { Contracts } from "../Contracts";
 
 export const usePicklePerBlock = (): { picklePerBlock: number | null } => {
-  const { address, blockNum } = Connection.useContainer();
+  const { blockNum } = Connection.useContainer();
   const { masterchef } = Contracts.useContainer();
   const [picklePerBlock, setPicklePerBlock] = useState<number | null>(null);
 
   const getData = async () => {
-    if (address && masterchef && blockNum) {
+    if (masterchef && blockNum) {
       // queue up the promises
       const promises = [
         masterchef.picklePerBlock(),
@@ -31,7 +31,7 @@ export const usePicklePerBlock = (): { picklePerBlock: number | null } => {
 
   useEffect(() => {
     getData();
-  }, [address, blockNum, masterchef]);
+  }, [blockNum, masterchef]);
 
   return { picklePerBlock };
 };

--- a/containers/Pickles/usePicklePerSecond.ts
+++ b/containers/Pickles/usePicklePerSecond.ts
@@ -7,13 +7,13 @@ export const usePicklePerSecond = (): {
   picklePerSecond: number | null;
   maticPerSecond: number | null;
 } => {
-  const { address, blockNum } = Connection.useContainer();
+  const { blockNum } = Connection.useContainer();
   const { minichef, pickleRewarder } = Contracts.useContainer();
   const [picklePerSecond, setPicklePerSecond] = useState<number | null>(null);
   const [maticPerSecond, setMaticPerSecond] = useState<number | null>(null);
 
   const getData = async () => {
-    if (address && minichef && blockNum && pickleRewarder) {
+    if (minichef && pickleRewarder) {
       const pps = await minichef
         .picklePerSecond()
         .catch(() => ethers.BigNumber.from(0));
@@ -28,7 +28,7 @@ export const usePicklePerSecond = (): {
 
   useEffect(() => {
     getData();
-  }, [address, blockNum, minichef]);
+  }, [blockNum, minichef]);
 
   return { picklePerSecond, maticPerSecond };
 };

--- a/containers/UserMiniFarms.ts
+++ b/containers/UserMiniFarms.ts
@@ -14,15 +14,10 @@ export interface UserFarmDataMatic extends UserFarmData {
   maticApy: number;
 }
 
-const BN_ZERO = BigNumber.from(0)
+const BN_ZERO = BigNumber.from(0);
 
 const useUserMiniFarms = (): { farmData: UserFarmDataMatic[] | null } => {
-  const {
-    blockNum,
-    address,
-    multicallProvider,
-    chainName,
-  } = Connection.useContainer();
+  const { blockNum, address, multicallProvider } = Connection.useContainer();
   const { minichef, erc20, pickleRewarder } = Contracts.useContainer();
   const { farms } = MiniFarms.useContainer();
   const { status: transferStatus } = ERC20Transfer.useContainer();
@@ -36,7 +31,7 @@ const useUserMiniFarms = (): { farmData: UserFarmDataMatic[] | null } => {
     if (pickleRewarder && farmData && address) {
       const userHarvestableMatic = await Promise.all(
         farmData.map((farm) => {
-          if(farm.staked.eq(BN_ZERO)) return Promise.resolve(BN_ZERO)
+          if (farm.staked.eq(BN_ZERO)) return Promise.resolve(BN_ZERO);
           return pickleRewarder
             .pendingToken(farm.poolIndex, address)
             .catch(() => BigNumber.from(0));
@@ -66,7 +61,7 @@ const useUserMiniFarms = (): { farmData: UserFarmDataMatic[] | null } => {
 
   useEffect(() => {
     updateMaticFarmData();
-  },[farmData])
+  }, [farmData]);
 
   return { farmData: farmDataMatic };
 };

--- a/features/Gauges/GaugeList.tsx
+++ b/features/Gauges/GaugeList.tsx
@@ -6,7 +6,6 @@ import Switch from "@material-ui/core/Switch";
 import { GaugeCollapsible } from "./GaugeCollapsible";
 import { UserGaugeData, UserGauges } from "../../containers/UserGauges";
 import { Connection } from "../../containers/Connection";
-import { useGaugeProxy } from "../../hooks/useGaugeProxy";
 import { VoteCollapsible } from "./VoteCollapsible";
 import { GaugeChartCollapsible } from "./GaugeChartCollapsible";
 import { MC2Farm } from "../MasterchefV2/MC2Farm";
@@ -48,8 +47,7 @@ export const GaugeList: FC = () => {
   const { signer } = Connection.useContainer();
   const { gaugeData } = UserGauges.useContainer();
   const [showInactive, setShowInactive] = useState<boolean>(false);
-  const [voteWeights, setVoteWeights] = useState<Weights>({});
-  const { status: voteTxStatus, vote } = useGaugeProxy();
+  const [voteWeights] = useState<Weights>({});
   const [showUserGauges, setShowUserGauges] = useState<boolean>(false);
   const { getUniPairDayAPY } = useUniPairDayData();
   const { jars } = Jars.useContainer();

--- a/features/MiniFarms/MiniFarmList.tsx
+++ b/features/MiniFarms/MiniFarmList.tsx
@@ -1,12 +1,11 @@
 import { FC, useState } from "react";
 import styled from "styled-components";
-import { Spacer, Grid, Checkbox, Button } from "@geist-ui/react";
+import { Spacer, Grid, Checkbox } from "@geist-ui/react";
 
 import { MiniFarmCollapsible } from "../MiniFarms/MiniFarmCollapsible";
 import { UserMiniFarms } from "../../containers/UserMiniFarms";
 import { Connection } from "../../containers/Connection";
 import { MiniIcon } from "../../components/TokenIcon";
-import { PICKLE_JARS } from "../../containers/Jars/jars";
 import { pickleWhite } from "../../util/constants";
 import { NETWORK_NAMES } from "containers/config";
 

--- a/util/benchark.ts
+++ b/util/benchark.ts
@@ -1,0 +1,40 @@
+/**
+ * Simple utilities to measure the speed of execution of
+ * a given block of code. The implementation makes it possible
+ * to profile code inside components, creating and stopping
+ * the timer only once given a unique timer name.
+ *
+ * Example usage:
+ *
+ * start("farms");
+ * const { farms } = MiniFarms.useContainer();
+ * end("farms", farms);
+ *
+ * The timer will be stopped as soon as variable `farms`
+ * holds a value. Note that `name` given to both `start`
+ * and `end` functions needs to be identical.
+ */
+export const start = (name: string) => {
+  if (typeof window === "undefined") return;
+
+  const key = `${name}_started`;
+
+  if (!(window as any)[key]) {
+    console.time(`tracking_${name}`);
+
+    (window as any)[key] = true;
+  }
+};
+
+export const end = (name: string, value: any) => {
+  if (typeof window === "undefined") return;
+
+  const key = `${name}_ended`;
+
+  if (!(window as any)[key]) {
+    if (value) {
+      console.timeEnd(`tracking_${name}`);
+      (window as any)[key] = true;
+    }
+  }
+};


### PR DESCRIPTION
Finally found a systematic approach to this issue which makes the fix(es) obvious.

First, we track execution times before changes so we know where to look at:

<img width="388" alt="before" src="https://user-images.githubusercontent.com/7811733/129435221-9707cf2c-b7ae-43c7-91ca-29d91d2bc978.png">

Notice how everything progresses smoothly until there's a huge step in execution time. Profiling code inside `farmsWithReward` reveals that it's fast. Hence, the problem is incomplete hooks dependencies. Because of that, data is fetched, but state is not refreshed and execution stalls.

More specifically, in case of Matic, there's a common scenario when `picklePerSecond` is fetched before `maticPerSecond` but not having `maticPerSecond` in hooks deps means state won't update once data is fetched.

Here's profiling after the change:

<img width="331" alt="fix" src="https://user-images.githubusercontent.com/7811733/129435302-9e5dd480-c6a5-4413-9e3d-46b0c4552eb5.png">

I believe there is no throttling happening and this is the real issue. **Farms should not take longer than 5 seconds to load.**

Steps to wrap this up:

- [x] add a multicall to `useWithReward` (see the marker above, we can potentially cut down load time by 30-50%)
- [x] profile mainnet code and apply any fixes
- [ ] _optional_ move `useFetchJars` to the API. Potential savings up to ~900ms. My original idea to move code to the API was a shot in the dark. Now we know exactly what moves the needle.

I'll leave the profiling code in the PR for a while so you can play with it in preview release. Will remove before merging but I'll keep to profiling utility around.

To verify your runtime results, open console and filter by `tracking`:

<img width="740" alt="tracking" src="https://user-images.githubusercontent.com/7811733/129435453-c1f81c85-6f87-4de6-ba90-3385c913ce60.png">
