### PR TITLE
Refresh jars data when it changes

### DIFF
--- a/containers/Jars/useJarsWithAPYEth.ts
+++ b/containers/Jars/useJarsWithAPYEth.ts
@@ -808,7 +808,7 @@ export const useJarWithAPY = (network: ChainName, jars: Input): Output => {
         calculateAbradabraApy(JAR_DEPOSIT_TOKENS.Ethereum.SPELL_ETH),
       ]);
 
-      const promises = jars.map(async (jar) => {
+      const newJarsWithAPY = jars.map((jar) => {
         let APYs: Array<JarApy> = [];
         let totalAPY = 0;
 
@@ -1094,15 +1094,13 @@ export const useJarWithAPY = (network: ChainName, jars: Input): Output => {
         };
       });
 
-      const newJarsWithAPY = await Promise.all(promises);
-
       setJarsWithAPY(newJarsWithAPY);
     }
   };
 
   useEffect(() => {
     if (network === NETWORK_NAMES.ETH) calculateAPY();
-  }, [jars?.length, prices, network, yearnData]);
+  }, [jars, prices, network, yearnData]);
 
   return { jarsWithAPY };
 };

--- a/containers/Jars/useJarsWithTVL.ts
+++ b/containers/Jars/useJarsWithTVL.ts
@@ -52,7 +52,7 @@ export const useJarWithTVL = (jars: Input): Output => {
 
   useEffect(() => {
     measureTVL();
-  }, [jars?.length, poolData?.length]);
+  }, [jars, poolData?.length]);
 
   return {
     jarsWithTVL,

--- a/containers/Jars/useYearnData.ts
+++ b/containers/Jars/useYearnData.ts
@@ -24,10 +24,11 @@ type YearnVaultsResponse = YearnVault[];
 export const useYearnData = () => {
   const [yearnData, setYearnData] = useState<YearnVaultsResponse | null>(null);
 
+  const fetchYearnData = async () =>
+    setYearnData(await fetch(YEARN_API).then((x) => x.json()));
+
   useEffect(() => {
-    const fetchYearnData = async () =>
-      setYearnData(await fetch(YEARN_API).then((x) => x.json()));
-    if (!yearnData) fetchYearnData();
+    fetchYearnData();
   }, []);
 
   return {

--- a/features/Gauges/JarGaugeCollapsible.tsx
+++ b/features/Gauges/JarGaugeCollapsible.tsx
@@ -514,7 +514,7 @@ export const JarGaugeCollapsible: FC<{
         });
         if (!res) throw "Deposit Failed";
         await depositGauge();
-        await sleep(10000)
+        await sleep(10000);
         setDepositStakeButton(null);
         setIsEntryBatch(false);
       } catch (error) {
@@ -535,7 +535,7 @@ export const JarGaugeCollapsible: FC<{
         setExitButton("Withdrawing from Jar...");
         const withdrawTx = await jarContract.connect(signer).withdrawAll();
         await withdrawTx.wait();
-        await sleep(10000)
+        await sleep(10000);
         setExitButton(null);
         setIsExitBatch(false);
       } catch (error) {
@@ -558,14 +558,14 @@ export const JarGaugeCollapsible: FC<{
             setZapStakeButton("Staking...");
             await depositGauge();
           }
-          await sleep(10000)
-          setDepositStakeButton(null)
+          await sleep(10000);
+          setDepositStakeButton(null);
           setZapOnlyButton(null);
           setZapStakeButton(null);
         } catch (error) {
           console.error(error);
           alert(error.message);
-          setDepositStakeButton(null)
+          setDepositStakeButton(null);
           setZapOnlyButton(null);
           setZapStakeButton(null);
           return;
@@ -774,7 +774,10 @@ export const JarGaugeCollapsible: FC<{
     >
       <Spacer y={1} />
       <Grid.Container gap={2}>
-        <Grid xs={24} md={depositedNum && (!isEntryBatch || stakedNum) ? 12 : 24}>
+        <Grid
+          xs={24}
+          md={depositedNum && (!isEntryBatch || stakedNum) ? 12 : 24}
+        >
           <div style={{ display: "flex", justifyContent: "space-between" }}>
             <div>
               Balance:{" "}


### PR DESCRIPTION
This is, more specifically, a fix fo the missing Yearn APY data. We need to be careful when we add hooks dependencies. Consider if we only care about the length of arrays (fewer rerenders) or array content that changes (more rerenders but correct content).