### PR TITLE
Fix missing Uniswap LP data on farms page

### DIFF
--- a/containers/Jars/useJarsWithAPYEth.ts
+++ b/containers/Jars/useJarsWithAPYEth.ts
@@ -125,7 +125,8 @@ export const useJarWithAPY = (network: ChainName, jars: Input): Output => {
     yearnRegistry,
     cvxBooster,
   } = Contracts.useContainer();
-  const { getUniPairDayAPY } = useUniPairDayData();
+  const { getUniPairDayAPY, uniPairDayData } = useUniPairDayData();
+
   const { getSushiPairDayAPY } = useSushiPairDayData();
   const { yearnData } = useYearnData();
   const { duneData } = useDuneData();
@@ -1098,9 +1099,15 @@ export const useJarWithAPY = (network: ChainName, jars: Input): Output => {
     }
   };
 
+  /**
+   * We only care about yearnData and uniPairDayData being present or not,
+   * so checking for array length is safe. However, this is not the case
+   * when it comes to jars, where the data changes while the array length
+   * remains the same.
+   */
   useEffect(() => {
     if (network === NETWORK_NAMES.ETH) calculateAPY();
-  }, [jars, prices, network, yearnData]);
+  }, [jars, prices, network, yearnData?.length, uniPairDayData?.length]);
 
   return { jarsWithAPY };
 };

--- a/containers/Jars/useUniPairDayData.ts
+++ b/containers/Jars/useUniPairDayData.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 
-import { Connection } from "../Connection";
 import { JAR_DEPOSIT_TOKENS } from "./jars";
 import { PICKLE_ETH_FARM } from "../Farms/farms";
 import { NETWORK_NAMES } from "containers/config";
@@ -29,8 +28,6 @@ const UNI_LP_TOKENS = [
 ];
 
 export const useUniPairDayData = () => {
-  const { signer } = Connection.useContainer();
-
   const [uniPairDayData, setUniPairDayData] = useState<Array<UniLPAPY> | null>(
     null,
   );
@@ -61,18 +58,14 @@ export const useUniPairDayData = () => {
 
   const getUniPairDayAPY = (pair: string) => {
     if (uniPairDayData) {
-      const filteredPair = uniPairDayData.filter(
-        (x) => {
-          return x.pairAddress.toLowerCase() === pair.toLowerCase()
-        }
+      const pairData = uniPairDayData.find(
+        (x) => x.pairAddress.toLowerCase() === pair.toLowerCase(),
       );
 
-      if (filteredPair.length > 0) {
-        const selected = filteredPair[0];
-
+      if (pairData) {
         // 0.3% fee to LP
         const apy =
-          (selected.dailyVolumeUSD / selected.reserveUSD) * 0.003 * 365 * 100;
+          (pairData.dailyVolumeUSD / pairData.reserveUSD) * 0.003 * 365 * 100;
 
         return [{ lp: apy }];
       }
@@ -87,5 +80,6 @@ export const useUniPairDayData = () => {
 
   return {
     getUniPairDayAPY,
+    uniPairDayData,
   };
 };


### PR DESCRIPTION
This fixes the data for farms where we get back data:

<img width="985" alt="Screen Shot 2021-09-07 at 12 14 59" src="https://user-images.githubusercontent.com/7811733/132287953-7d3a6cfa-0cb5-4b39-8e73-ef0f6cc397b9.png">

something seems to be wrong with Uniswap's API. E.g. it's returning 0 volume for FEI/TRIBE (and a bunch of others):

<img width="1172" alt="Screen Shot 2021-09-07 at 12 20 26" src="https://user-images.githubusercontent.com/7811733/132288419-970ac233-1fa9-431c-a17c-e8258faab104.png">

even though the [volume is $5M+](https://v2.info.uniswap.org/pair/0x9928e4046d7c6513326ccea028cd3e7a91c7590a).

cc @robstryker 