### PR TITLE
Update GaugeList.tsx

### DIFF
--- a/features/Gauges/GaugeList.tsx
+++ b/features/Gauges/GaugeList.tsx
@@ -104,6 +104,10 @@ export const GaugeList: FC = () => {
       totalAPY,
     };
   });
+  
+  const harvestableFarms = gaugeData
+    .filter((g) => !g.harvestable.isZero())
+    .map((x) => x.address);
 
   const isDisabledFarm = (depositToken: string) =>
     depositToken === PICKLE_JARS.pUNIETHLUSD;


### PR DESCRIPTION
Add a list of farms with non-zero harvestable amounts. Might be useful to populate a list of addresses to pass to a global harvester contract