### PR TITLE
Remove mim from vote and include notice

### DIFF
--- a/features/Gauges/GaugeList.tsx
+++ b/features/Gauges/GaugeList.tsx
@@ -200,7 +200,8 @@ export const GaugeList: FC = () => {
         gauges={activeGauges.filter(
           (x) =>
             x.depositToken.address != PICKLE_JARS.pSUSHIETHYVECRV &&
-            x.depositToken.address.toLowerCase() != PICKLE_ETH_FARM,
+            x.depositToken.address.toLowerCase() != PICKLE_ETH_FARM &&
+            x.depositToken.address != PICKLE_JARS.pMIMETH
         )}
       />
       <div

--- a/features/Gauges/JarGaugeCollapsible.tsx
+++ b/features/Gauges/JarGaugeCollapsible.tsx
@@ -459,6 +459,10 @@ export const JarGaugeCollapsible: FC<{
     depositToken.address.toLowerCase() ===
     JAR_DEPOSIT_TOKENS[NETWORK_NAMES.ETH].SUSHI_ETH_YVECRV.toLowerCase();
 
+  const isMimJar =
+    depositToken.address.toLowerCase() ===
+    JAR_DEPOSIT_TOKENS.Ethereum.MIM_ETH.toLowerCase();
+
   const depositGauge = async () => {
     if (!approved) {
       setDepositStakeButton(t("farms.approving"));
@@ -859,6 +863,9 @@ export const JarGaugeCollapsible: FC<{
                   : depositButton.text}
                 {isZap && ZapperIcon}
               </Button>
+              {isMimJar ? (
+                <StyledNotice>{t("farms.abra.rewardsEnded")}</StyledNotice>
+              ) : null}
             </Grid>
             <Grid xs={24} md={12}>
               <Button
@@ -1128,3 +1135,10 @@ export const JarGaugeCollapsible: FC<{
     </Collapse>
   );
 };
+
+const StyledNotice = styled.div`
+  width: "100%";
+  textalign: "center";
+  paddingtop: "6px";
+  fontfamily: "Source Sans Pro";
+`;

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -69,6 +69,9 @@
       "description": "A 0.5% fee is charged by Mai Finance upon depositing",
       "rewardsEnded": "Rewards have ended. Consider depositing in the new QI/MATIC Jar"
     },
+    "abra": {
+      "rewardsEnded": "Note: SPELL rewards have ended for MIM/ETH"
+    },
     "mc2": "SushiSwap MasterChefv2",
     "mc2detail": "PICKLE and SUSHI automatically harvested on staking and unstaking.",
     "migrated": "Migrated! Staking in Farm...",


### PR DESCRIPTION
SPELL rewards on MIM-ETH have ended on mainnet (in favour of Arbitrum), so voting for this Jar on the frontend has been disabled. 