### PR TITLE
Extract FarmsIntro

### DIFF
--- a/components/FarmsIntro.tsx
+++ b/components/FarmsIntro.tsx
@@ -1,0 +1,39 @@
+import { FC } from "react";
+import { Trans, useTranslation } from "next-i18next";
+
+import { Connection } from "../containers/Connection";
+import { NETWORK_NAMES } from "containers/config";
+import { MiniIcon } from "../components/TokenIcon";
+
+export const FarmsIntro: FC = () => {
+  const { chainName } = Connection.useContainer();
+  const { t } = useTranslation("common");
+
+  const isPolygon = chainName === NETWORK_NAMES.POLY;
+
+  if (isPolygon)
+    return (
+      <p>
+        <Trans i18nKey="farms.polygon.description">
+          Farms allow you to earn dual PICKLE
+          <MiniIcon source="/pickle.png" /> and MATIC
+          <MiniIcon source="/matic.png" /> rewards by staking tokens. (Note:
+          MATIC rewards end August 23)
+        </Trans>
+        <br />
+        {t("farms.apy")}
+      </p>
+    );
+
+  return (
+    <p>
+      <Trans i18nKey="farms.intro">
+        Jars auto-invest your deposit tokens and Farms earn you{" "}
+        <strong>$PICKLEs</strong>.
+        <br />
+        Deposit & Stake to get into both. Hover over the displayed APY to see
+        where the returns are coming from.
+      </Trans>
+    </p>
+  );
+};

--- a/features/Gauges/GaugeList.tsx
+++ b/features/Gauges/GaugeList.tsx
@@ -25,7 +25,8 @@ import { Jars } from "../../containers/Jars";
 import { NETWORK_NAMES } from "containers/config";
 import { UserJarData } from "containers/UserJars";
 import { BigNumber } from "ethers";
-import { Trans, useTranslation } from "next-i18next";
+import { useTranslation } from "next-i18next";
+import { FarmsIntro } from "components/FarmsIntro";
 
 export interface UserGaugeDataWithAPY extends UserGaugeData {
   APYs: Array<JarApy>;
@@ -166,15 +167,7 @@ export const GaugeList: FC = () => {
       <Spacer y={1} />
       <Grid.Container>
         <Grid md={12}>
-          <p>
-            <Trans i18nKey="farms.intro">
-              Jars auto-invest your deposit tokens and Farms earn you{" "}
-              <strong>$PICKLEs</strong>.
-              <br />
-              Deposit & Stake to get into both. Hover over the displayed APY to
-              see where the returns are coming from.
-            </Trans>
-          </p>
+          <FarmsIntro />
         </Grid>
         <Grid md={12} style={{ textAlign: "right" }}>
           <Checkbox
@@ -201,7 +194,7 @@ export const GaugeList: FC = () => {
           (x) =>
             x.depositToken.address != PICKLE_JARS.pSUSHIETHYVECRV &&
             x.depositToken.address.toLowerCase() != PICKLE_ETH_FARM &&
-            x.depositToken.address != PICKLE_JARS.pMIMETH
+            x.depositToken.address != PICKLE_JARS.pMIMETH,
         )}
       />
       <div

--- a/features/MiniFarms/MiniFarmList.tsx
+++ b/features/MiniFarms/MiniFarmList.tsx
@@ -1,12 +1,10 @@
 import { FC, useState } from "react";
 import styled from "styled-components";
 import { Spacer, Grid, Checkbox } from "@geist-ui/react";
-import { Trans, useTranslation } from "next-i18next";
+import { useTranslation } from "next-i18next";
 
-import { MiniFarmCollapsible } from "../MiniFarms/MiniFarmCollapsible";
 import { UserMiniFarms } from "../../containers/UserMiniFarms";
 import { Connection } from "../../containers/Connection";
-import { MiniIcon } from "../../components/TokenIcon";
 import { useJarData } from "features/Gauges/useJarData";
 import { JAR_FARM_MAP } from "../../containers/Farms/farms";
 import { JAR_ACTIVE } from "../../containers/Jars/jars";
@@ -14,8 +12,8 @@ import { JarMiniFarmCollapsible } from "./JarMiniFarmCollapsible";
 import { uncompoundAPY } from "../../util/jars";
 import { NETWORK_NAMES } from "containers/config";
 import { BalFarm } from "../PickleFarms/BalFarm";
-import { copySync } from "fs-extra";
 import { pickleWhite } from "util/constants";
+import { FarmsIntro } from "components/FarmsIntro";
 
 const Container = styled.div`
   padding-top: 1.5rem;
@@ -115,9 +113,6 @@ export const MiniFarmList: FC = () => {
     (jar) => !JAR_ACTIVE[jar.depositTokenName],
   );
 
-  const activeFarms = farmData?.filter((x) => x.maticApy !== 0);
-  const inactiveFarms = farmData?.filter((x) => x.maticApy === 0);
-
   return (
     <Container>
       {chainName === NETWORK_NAMES.ARB && (
@@ -128,16 +123,7 @@ export const MiniFarmList: FC = () => {
       )}
       <Grid.Container gap={1}>
         <Grid md={16}>
-          <p>
-            <Trans i18nKey="farms.polygon.description">
-              Farms allow you to earn dual PICKLE
-              <MiniIcon source="/pickle.png" /> and MATIC
-              <MiniIcon source="/matic.png" /> rewards by staking tokens. (Note:
-              MATIC rewards end August 23)
-            </Trans>
-            <br />
-            {t("farms.apy")}
-          </p>
+          <FarmsIntro />
         </Grid>
         <Grid md={8} style={{ textAlign: "right" }}>
           <Checkbox


### PR DESCRIPTION
Standalone component to show above farms. Right now, Arbitrum was showing what was meant for Polygon so this will be easier to maintain.