### PR TITLE
Tweak fee distribution chart seemingly negative series

### DIFF
--- a/features/DILL/FeeDistributionsChart.tsx
+++ b/features/DILL/FeeDistributionsChart.tsx
@@ -152,7 +152,12 @@ export const FeeDistributionsChart: FC = () => {
                 interval={0}
                 tickMargin={26}
               />
-              <YAxis width={90} padding={{ top: 20 }}>
+              <YAxis
+                width={90}
+                padding={{ top: 20 }}
+                domain={[-5000, 135000]}
+                tickCount={5}
+              >
                 <Label
                   value={t("dill.tokenAmount") as string}
                   position="insideLeft"


### PR DESCRIPTION
This little fix explicitly specifies -5000 as the minimum value of left y-axis. This results in the PICKLE/DILL series to be rendered in the positive territory so it is more intuitive to grasp at first sight.

![image](https://user-images.githubusercontent.com/7811733/135747619-39a8dcf7-99d5-4afd-ad1c-55d46f086d01.png)

Closes #169 