### PR TITLE
Fixes #126 - tiny approvals lead to failed transactions

### DIFF
--- a/containers/Erc20Transfer.ts
+++ b/containers/Erc20Transfer.ts
@@ -23,6 +23,7 @@ interface TransferFunction {
   recipient: string;
   transferCallback: () => Promise<TransactionResponse>;
   approval?: boolean;
+  approvalAmountRequired?: ethers.BigNumber;
 }
 
 function useERC20Transfer() {
@@ -36,12 +37,13 @@ function useERC20Transfer() {
     recipient,
     transferCallback,
     approval = true,
+    approvalAmountRequired = ethers.constants.MaxUint256,
   }: TransferFunction) => {
     if (erc20 && address && provider && signer) {
       if (approval) {
         const Token = erc20.attach(token).connect(signer);
         const allowance = await Token.allowance(address, recipient);
-        if (allowance.lte(ethers.constants.Zero)) {
+        if (allowance.lte(approvalAmountRequired)) {
           setTransferStatus(token, recipient, Status.Approving);
 
           try {

--- a/containers/Erc20Transfer.ts
+++ b/containers/Erc20Transfer.ts
@@ -43,7 +43,7 @@ function useERC20Transfer() {
       if (approval) {
         const Token = erc20.attach(token).connect(signer);
         const allowance = await Token.allowance(address, recipient);
-        if (allowance.lte(approvalAmountRequired)) {
+        if (allowance.lt(approvalAmountRequired)) {
           setTransferStatus(token, recipient, Status.Approving);
 
           try {

--- a/features/Gauges/JarGaugeCollapsible.tsx
+++ b/features/Gauges/JarGaugeCollapsible.tsx
@@ -521,6 +521,7 @@ export const JarGaugeCollapsible: FC<{
         const res = await transfer({
           token: depositToken.address,
           recipient: jarContract.address,
+          approvalAmountRequired: convertDecimals(depositAmount),
           transferCallback: async () => {
             return jarContract
               .connect(signer)
@@ -858,6 +859,7 @@ export const JarGaugeCollapsible: FC<{
                     transfer({
                       token: depositToken.address,
                       recipient: jarContract.address,
+                      approvalAmountRequired: convertDecimals(depositAmount),
                       transferCallback: async () => {
                         return jarContract
                           .connect(signer)

--- a/features/MiniFarms/JarCollapsible.tsx
+++ b/features/MiniFarms/JarCollapsible.tsx
@@ -504,15 +504,15 @@ export const JarCollapsible: FC<{
             onClick={() => {
               if (signer) {
                 // Allow Jar to get LP Token
+                const depositAmt = ethers.utils.parseUnits(depositAmount, isUsdc ? 6 : 18);
                 transfer({
                   token: depositToken.address,
                   recipient: jarContract.address,
+                  approvalAmountRequired: depositAmt ,
                   transferCallback: async () => {
                     return jarContract
                       .connect(signer)
-                      .deposit(
-                        ethers.utils.parseUnits(depositAmount, isUsdc ? 6 : 18),
-                      );
+                      .deposit(depositAmt);
                   },
                 });
               }

--- a/features/MiniFarms/JarMiniFarmCollapsible.tsx
+++ b/features/MiniFarms/JarMiniFarmCollapsible.tsx
@@ -343,6 +343,7 @@ export const JarMiniFarmCollapsible: FC<{
         const res = await transfer({
           token: depositToken.address,
           recipient: jarContract.address,
+          approvalAmountRequired: parseEther(depositAmount),
           transferCallback: async () => {
             return jarContract
               .connect(signer)
@@ -657,6 +658,7 @@ export const JarMiniFarmCollapsible: FC<{
                     transfer({
                       token: depositToken.address,
                       recipient: jarContract.address,
+                      approvalAmountRequired: parseEther(depositAmount),
                       transferCallback: async () => {
                         return jarContract
                           .connect(signer)
@@ -772,6 +774,7 @@ export const JarMiniFarmCollapsible: FC<{
                     transfer({
                       token: farmDepositToken.address,
                       recipient: minichef.address,
+                      approvalAmountRequired: farmBalance,
                       transferCallback: async () => {
                         return minichef.deposit(
                           poolIndex,

--- a/features/MiniFarms/MiniFarmCollapsible.tsx
+++ b/features/MiniFarms/MiniFarmCollapsible.tsx
@@ -279,6 +279,7 @@ export const MiniFarmCollapsible: FC<{ farmData: UserFarmDataMatic }> = ({
                 transfer({
                   token: depositToken.address,
                   recipient: minichef.address,
+                  approvalAmountRequired: ethers.utils.parseEther(stakeAmount),
                   transferCallback: async () => {
                     return minichef
                       .connect(signer)

--- a/features/PickleFarms/MC2Farm.tsx
+++ b/features/PickleFarms/MC2Farm.tsx
@@ -241,6 +241,7 @@ export const MC2Farm: FC = () => {
                 transfer({
                   token: PICKLE_ETH_SLP,
                   recipient: masterchefV2.address,
+                  approvalAmountRequired: ethers.utils.parseEther(stakeAmount),
                   transferCallback: async () => {
                     return masterchefV2
                       .connect(signer)


### PR DESCRIPTION
Signed-off-by: rawbdor <rawblem@gmail.com>

Needs to be tested. 
Steps to test:

On polygon or some other cheap chain:
1) Get some small number of LP tokens for a random pool
2) Approve only 50% of your tokens for deposit. 
3) Deposit only 25% of your tokens, leaving you with 25% left.
4) Try to deposit the remainder into the jar
5) Old behavior: app would not ask for new approvals, deposit would be rejected.
   New behavior (hoped): app will recognize you do not have enough tokens approved. 