### PR TITLE
Fixes #250 - a balanceOf multicall to a non-erc20 contract

### DIFF
--- a/containers/Jars.ts
+++ b/containers/Jars.ts
@@ -24,7 +24,9 @@ function useJars() {
   // Automatically update balance here
   useEffect(() => {
     if (jarsWithTVL) {
-      const wants = jarsWithTVL.map((x) => x.depositToken.address);
+      const wants = jarsWithTVL
+      .filter(x => x.isErc20)
+      .map((x) => x.depositToken.address);
       const pTokens = jarsWithTVL.map((x) => x.contract.address);
       const addedTokens = [...wants, ...pTokens];
       if (chainName === NETWORK_NAMES.ETH)

--- a/containers/Jars/useFetchJars.ts
+++ b/containers/Jars/useFetchJars.ts
@@ -22,6 +22,7 @@ export type Jar = {
   protocol: string;
   chain: ChainNetwork;
   apiKey: string;
+  isErc20: boolean;
 };
 
 export const useFetchJars = (): { jars: Array<Jar> | null } => {
@@ -67,6 +68,7 @@ export const useFetchJars = (): { jars: Array<Jar> | null } => {
           protocol: x.protocol,
           chain: x.chain,
           apiKey: x.details.apiKey,
+          isErc20: x.depositToken.style?.erc20?? true, 
         };
 
         return z;


### PR DESCRIPTION
A uni v3 contract address included in a `balanceOf` multicall causing the call to revert.