### PR TITLE
Fixes #276 - only show jars the user is in, but transition could be nicer

### DIFF
--- a/pages/v2/index.tsx
+++ b/pages/v2/index.tsx
@@ -22,7 +22,7 @@ const Dashboard: PickleFinancePage = () => {
           <DillBalanceCard />
         </div>
       </div>
-      <FarmsTable title={t("v2.dashboard.joinedFarms")} simple />
+      <FarmsTable title={t("v2.dashboard.joinedFarms")} simple dashboard/>
       <div className="mt-4">
         <DashboardCalloutCard />
       </div>

--- a/v2/features/farms/FarmsTable.tsx
+++ b/v2/features/farms/FarmsTable.tsx
@@ -15,9 +15,10 @@ const FarmsTableHeaderCell: FC = ({ children }) => (
 interface Props {
   simple?: boolean;
   title: string;
+  dashboard: boolean;
 }
 
-const FarmsTable: FC<Props> = ({ simple, title }) => {
+const FarmsTable: FC<Props> = ({ simple, title, dashboard }) => {
   const { t } = useTranslation("common");
 
   return (
@@ -49,7 +50,7 @@ const FarmsTable: FC<Props> = ({ simple, title }) => {
                 </tr>
               </thead>
               <tbody className="text-white">
-                <FarmsTableBody simple={simple} />
+                <FarmsTableBody simple={simple} dashboard={dashboard}/>
               </tbody>
             </table>
           </div>

--- a/v2/features/farms/FarmsTableBody.tsx
+++ b/v2/features/farms/FarmsTableBody.tsx
@@ -4,15 +4,27 @@ import { useSelector } from "react-redux";
 
 import FarmsTableRow from "./FarmsTableRow";
 import { CoreSelectors } from "v2/store/core";
+import { UserSelectors } from "v2/store/user";
+import { UserData, UserTokenData } from "picklefinance-core/lib/client/UserModel";
 
 interface Props {
   simple?: boolean;
+  dashboard?: boolean;
 }
 
-const FarmsTableBody: FC<Props> = ({ simple }) => {
+const FarmsTableBody: FC<Props> = ({ simple, dashboard }) => {
   const { t } = useTranslation("common");
   const loading = useSelector(CoreSelectors.selectLoadingState);
-  const jars = useSelector(CoreSelectors.selectEnabledJars);
+  const userModel: UserData | undefined = useSelector(UserSelectors.selectData);
+
+  // TODO Should be all assets, not just jars
+  let jars = useSelector(CoreSelectors.selectEnabledJars);
+  if( dashboard && userModel) {
+    const empty = (val:string) => val !== undefined && val !== "0";
+    const showAsset = (x:UserTokenData):boolean => !empty(x.pAssetBalance) || !empty(x.pStakedBalance) || !empty(x.picklePending);
+    const apiKeys:string[] = userModel.tokens.filter((x)=> showAsset(x)).map((x)=>x.assetKey);
+    jars = jars.filter((x) => apiKeys.includes(x.details.apiKey));
+  }
 
   if (loading !== "fulfilled") {
     return (


### PR DESCRIPTION
Page first shows up with all jars, then switches to only the ones you have. Not ideal, but not bad. 