### PR TITLE
fixes #296

### DIFF
--- a/v2/features/connection/ConnectionStatus.tsx
+++ b/v2/features/connection/ConnectionStatus.tsx
@@ -149,12 +149,14 @@ const ConnectionStatus: FC = () => {
   let { error, chainId } = useWeb3React<Web3Provider>();
   const supportedChains: number[] = Chains.list().map((x) => Chains.get(x).id);
 
+  if (!chainId) 
+    return null;
   if (!isRelevantError(error) && chainId && supportedChains.includes(chainId))
     return null;
   if (!error && !(chainId && supportedChains.includes(chainId))) {
     // App will function with all known chains
     // supportedChains contains all chains Pickle supports
-    // we want error if Chain is not in supportedChains
+    // we want error if chainId is not in supportedChains
     error = new UnsupportedChainIdError(
       chainId ? chainId : -1,
       supportedChains,


### PR DESCRIPTION
The unsupported network popup default state has been fixed, however the wallet connect button has a similar issue now. It seems there is another issue (#273) regarding this same button so it might make sense to close this one and add the task of correcting the button behavior to that issue where other decisions need to be made about this button.