### PR TITLE
Add pagination to farms

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "printWidth": 100,
+  "trailingComma": "all"
+}

--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
     "tsc": "tsc",
     "typechain": "typechain --target ethers-v5 --outDir ./containers/Contracts ./containers/ABIs/**/*.json"
   },
-  "prettier": {
-    "trailingComma": "all"
-  },
   "dependencies": {
     "@davatar/react": "^1.8.1",
     "@ethersproject/abstract-provider": "^5.0.4",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -372,6 +372,7 @@
       "network": "Network",
       "noResults": "No results",
       "notMatchingAllFilters": "Showing farms matching at least one filter",
+      "pagination": "Page {{ current }} of {{ total }}",
       "protocol": "Protocol",
       "stakedToken": "{{ token }} staked",
       "token": "Token"
@@ -390,7 +391,9 @@
       "feedback": "Feedback",
       "jarsAndFarms": "Jars & Farms",
       "networkSettings": "Network settings",
+      "next": "Next",
       "openMenu": "Open main menu",
+      "previous": "Prev",
       "stats": "Stats",
       "tokenAddress": "Token address"
     },

--- a/v2/components/PerformanceCard.tsx
+++ b/v2/components/PerformanceCard.tsx
@@ -25,13 +25,9 @@ export const getTotalBalances = (
   let runningUsd = 0;
   for (let i = 0; i < userdata.tokens.length; i++) {
     const key = userdata.tokens[i].assetKey;
-    const jar = core.assets.jars.find((x) => x.details.apiKey === key);
+    const jar = core.assets.jars.find((x) => x.details?.apiKey === key);
     if (jar) {
-      const data: UserAssetDataWithPrices = getUserAssetDataWithPrices(
-        jar,
-        core,
-        userdata,
-      );
+      const data: UserAssetDataWithPrices = getUserAssetDataWithPrices(jar, core, userdata);
       if (data) {
         runningUsd += data.depositTokensInJar.tokensUSD || 0;
         runningUsd += data.depositTokensInFarm.tokensUSD || 0;
@@ -52,8 +48,7 @@ export const getPendingRewardsUsd = (
   }
   if (userdata.dill && userdata.dill.claimable) {
     const wei: BigNumber = BigNumber.from(userdata.dill.claimable);
-    const dillRewardUsd =
-      wei.div(1e10).div(1e8).toNumber() * core.prices.pickle;
+    const dillRewardUsd = wei.div(1e10).div(1e8).toNumber() * core.prices.pickle;
     runningUsd += dillRewardUsd;
   }
   return formatUsd(runningUsd);
@@ -66,7 +61,7 @@ export const getPendingHarvestsUsd = (
   let runningUsd = 0;
   for (let i = 0; i < userdata.tokens.length; i++) {
     const key = userdata.tokens[i].assetKey;
-    const jar = core.assets.jars.find((x) => x.details.apiKey === key);
+    const jar = core.assets.jars.find((x) => x.details?.apiKey === key);
     const totalPTokens = jar?.details.tokenBalance;
     if (totalPTokens) {
       const userShare =
@@ -90,13 +85,9 @@ export const getUserAssetDataWithPricesForJars = (
   const ret: UserAssetDataWithPrices[] = [];
   for (let i = 0; i < userdata.tokens.length; i++) {
     const key = userdata.tokens[i].assetKey;
-    const jar = core.assets.jars.find((x) => x.details.apiKey === key);
+    const jar = core.assets.jars.find((x) => x.details?.apiKey === key);
     if (jar) {
-      const data: UserAssetDataWithPrices = getUserAssetDataWithPrices(
-        jar,
-        core,
-        userdata,
-      );
+      const data: UserAssetDataWithPrices = getUserAssetDataWithPrices(jar, core, userdata);
       if (data) {
         ret.push(data);
       }
@@ -105,23 +96,18 @@ export const getUserAssetDataWithPricesForJars = (
   return ret;
 };
 
-export const getAllPickleAssets = (
-  core: PickleModelJson.PickleModelJson,
-): PickleAsset[] => {
-  const ret: PickleAsset[] = [];
-  return ret
-    .concat(core.assets.jars)
-    .concat(core.assets.standaloneFarms)
-    .concat(core.assets.external);
-};
+export const getAllPickleAssets = (core: PickleModelJson.PickleModelJson): PickleAsset[] => [
+  ...core.assets.jars,
+  ...core.assets.standaloneFarms,
+  ...core.assets.external,
+];
+
 export const userVisibleStringForPickleAsset = (
   apiKey: string,
   core: PickleModelJson.PickleModelJson,
 ): string | undefined => {
   const allAssets: PickleAsset[] = getAllPickleAssets(core);
-  const asset: PickleAsset | undefined = allAssets.find(
-    (x) => x.details.apiKey === apiKey,
-  );
+  const asset: PickleAsset | undefined = allAssets.find((x) => x.details?.apiKey === apiKey);
   return asset ? asset.depositToken.name : undefined;
 };
 
@@ -144,8 +130,7 @@ export const getRewardRowPropertiesForRewards = (
     },
   };
   for (let i = 0; i < jarData.length; i++) {
-    const descriptor =
-      userVisibleStringForPickleAsset(jarData[i].assetId, core) || "unknown";
+    const descriptor = userVisibleStringForPickleAsset(jarData[i].assetId, core) || "unknown";
     const earnedPickles = parseFloat(jarData[i].earnedPickles.tokens);
     if (earnedPickles > 0) {
       ret.push({
@@ -175,16 +160,11 @@ const PerformanceCard: FC = () => {
   const userModel: UserData | undefined = useSelector(UserSelectors.selectData);
 
   const allCore = useSelector(CoreSelectors.selectCore);
-  const userTotalBalance =
-    allCore && userModel ? getTotalBalances(allCore, userModel) : 0;
-  const unclaimedRewards =
-    allCore && userModel ? getPendingRewardsUsd(allCore, userModel) : 0;
-  const pendingHarvest =
-    allCore && userModel ? getPendingHarvestsUsd(allCore, userModel) : 0;
+  const userTotalBalance = allCore && userModel ? getTotalBalances(allCore, userModel) : 0;
+  const unclaimedRewards = allCore && userModel ? getPendingRewardsUsd(allCore, userModel) : 0;
+  const pendingHarvest = allCore && userModel ? getPendingHarvestsUsd(allCore, userModel) : 0;
   const rewardRowProps: RewardRowProps[] =
-    allCore && userModel
-      ? getRewardRowPropertiesForRewards(allCore, userModel)
-      : [];
+    allCore && userModel ? getRewardRowPropertiesForRewards(allCore, userModel) : [];
   const openModal = () => setIsOpen(true);
   const closeModal = () => setIsOpen(false);
 
@@ -200,12 +180,8 @@ const PerformanceCard: FC = () => {
               <CashIcon className="text-foreground-button" />
             </div>
             <div>
-              <p className="font-title font-medium text-2xl leading-7 mb-1">
-                {userTotalBalance}
-              </p>
-              <p className="text-foreground-alt-200 text-sm">
-                {t("v2.balances.balance")}
-              </p>
+              <p className="font-title font-medium text-2xl leading-7 mb-1">{userTotalBalance}</p>
+              <p className="text-foreground-alt-200 text-sm">{t("v2.balances.balance")}</p>
             </div>
           </div>
           <div className="flex mb-6 xl:mb-0">
@@ -220,9 +196,7 @@ const PerformanceCard: FC = () => {
               />
             </div>
             <div>
-              <p className="font-title font-medium text-2xl leading-7 mb-1">
-                {unclaimedRewards}
-              </p>
+              <p className="font-title font-medium text-2xl leading-7 mb-1">{unclaimedRewards}</p>
               <p className="text-foreground-alt-200 text-sm">
                 {t("v2.dashboard.unclaimedRewards")}
               </p>
@@ -233,12 +207,8 @@ const PerformanceCard: FC = () => {
               <ClockIcon className="text-foreground-button" />
             </div>
             <div>
-              <p className="font-title font-medium text-2xl leading-7 mb-1">
-                {pendingHarvest}
-              </p>
-              <p className="text-foreground-alt-200 text-sm">
-                {t("v2.dashboard.pendingHarvests")}
-              </p>
+              <p className="font-title font-medium text-2xl leading-7 mb-1">{pendingHarvest}</p>
+              <p className="text-foreground-alt-200 text-sm">{t("v2.dashboard.pendingHarvests")}</p>
             </div>
           </div>
         </div>
@@ -247,11 +217,7 @@ const PerformanceCard: FC = () => {
         <Button onClick={openModal} size="normal">
           {t("v2.dashboard.harvestRewards")}
         </Button>
-        <HarvestModal
-          isOpen={isOpen}
-          closeModal={closeModal}
-          harvestables={rewardRowProps}
-        />
+        <HarvestModal isOpen={isOpen} closeModal={closeModal} harvestables={rewardRowProps} />
       </div>
     </div>
   );

--- a/v2/features/farms/FarmControls.tsx
+++ b/v2/features/farms/FarmControls.tsx
@@ -2,6 +2,7 @@ import { FC } from "react";
 
 import FarmSearch from "./FarmSearch";
 import MatchAllFiltersToggle from "./MatchAllFiltersToggle";
+import Pagination from "./Pagination";
 
 const FarmControls: FC = () => {
   return (
@@ -9,7 +10,10 @@ const FarmControls: FC = () => {
       <div className="w-1/2 sm:w-2/5 mb-2 sm:mb-0 sm:mr-3">
         <FarmSearch />
       </div>
-      <MatchAllFiltersToggle />
+      <div className="flex grow justify-between">
+        <MatchAllFiltersToggle />
+        <Pagination />
+      </div>
     </div>
   );
 };

--- a/v2/features/farms/FarmSearch.tsx
+++ b/v2/features/farms/FarmSearch.tsx
@@ -1,10 +1,5 @@
 import React, { FC, useState } from "react";
-import Select, {
-  components,
-  StylesConfig,
-  ControlProps,
-  OptionProps,
-} from "react-select";
+import Select, { components, StylesConfig, ControlProps, OptionProps } from "react-select";
 import Image from "next/image";
 import { useTranslation } from "next-i18next";
 import chroma from "chroma-js";
@@ -120,9 +115,7 @@ const styles: StylesConfig<Filter> = {
   multiValueRemove: (styles, { data }) => ({
     ...styles,
     color:
-      chroma.contrast(data.color, "white") >= 7
-        ? "white"
-        : chroma(data.color).darken(2.5).css(),
+      chroma.contrast(data.color, "white") >= 7 ? "white" : chroma(data.color).darken(2.5).css(),
     ":hover": {
       color: "white",
       backgroundColor: "rgb(var(--color-accent))",
@@ -130,9 +123,7 @@ const styles: StylesConfig<Filter> = {
   }),
   option: (styles, { data, isFocused }) => ({
     ...styles,
-    backgroundColor: isFocused
-      ? "rgb(var(--color-background-lightest))"
-      : undefined,
+    backgroundColor: isFocused ? "rgb(var(--color-background-lightest))" : undefined,
     borderRadius: 10,
     color: data.color,
     transition: "all 200ms ease-in-out",

--- a/v2/features/farms/FarmsTableRow.tsx
+++ b/v2/features/farms/FarmsTableRow.tsx
@@ -5,7 +5,7 @@ import { classNames } from "v2/utils";
 import FarmsTableSpacerRow from "./FarmsTableSpacerRow";
 import FarmsTableRowHeader from "./FarmsTableRowHeader";
 import FarmsTableRowBody from "./FarmsTableRowBody";
-import { JarWithData } from "./FarmsTableBody";
+import { JarWithData } from "v2/store/core";
 
 interface Props {
   simple?: boolean;
@@ -31,10 +31,7 @@ const FarmsTableRow: FC<Props> = ({ jar, simple }) => {
             <Disclosure.Button
               as="tr"
               // No hover state when the row is expaned.
-              className={classNames(
-                !open && "group",
-                !simple && "cursor-pointer",
-              )}
+              className={classNames(!open && "group", !simple && "cursor-pointer")}
             >
               <FarmsTableRowHeader open={open} simple={simple} jar={jar} />
             </Disclosure.Button>

--- a/v2/features/farms/FarmsTableRowHeader.tsx
+++ b/v2/features/farms/FarmsTableRowHeader.tsx
@@ -2,23 +2,15 @@ import { FC, HTMLAttributes } from "react";
 import Image from "next/image";
 import { ChevronDownIcon } from "@heroicons/react/solid";
 import { BigNumber } from "@ethersproject/bignumber";
-import {
-  JarDefinition,
-  PickleModelJson,
-} from "picklefinance-core/lib/model/PickleModelJson";
-import {
-  UserData,
-  UserTokenData,
-} from "picklefinance-core/lib/client/UserModel";
+import { JarDefinition, PickleModelJson } from "picklefinance-core/lib/model/PickleModelJson";
+import { UserData, UserTokenData } from "picklefinance-core/lib/client/UserModel";
 
 import { bigNumberToTokenNumber, classNames, formatDollars } from "v2/utils";
 import FarmsBadge from "./FarmsBadge";
 import { useSelector } from "react-redux";
-import { UserSelectors } from "v2/store/user";
-import { CoreSelectors } from "v2/store/core";
+import { CoreSelectors, JarWithData } from "v2/store/core";
 import FarmComponentsIcons from "./FarmComponentsIcons";
 import { Network } from "../connection/networks";
-import { JarWithData } from "./FarmsTableBody";
 
 const RowCell: FC<HTMLAttributes<HTMLElement>> = ({ children, className }) => (
   <td
@@ -30,10 +22,7 @@ const RowCell: FC<HTMLAttributes<HTMLElement>> = ({ children, className }) => (
     {children}
   </td>
 );
-const chainProtocol = (
-  jar: JarDefinition,
-  networks: Network[] | undefined,
-): JSX.Element => {
+const chainProtocol = (jar: JarDefinition, networks: Network[] | undefined): JSX.Element => {
   return (
     <div>
       <p className="font-title font-medium text-base leading-5 group-hover:text-primary-light transition duration-300 ease-in-out">
@@ -51,9 +40,7 @@ const chainProtocol = (
             title={jar.chain}
           />
         </div>
-        <p className="italic font-normal text-xs text-foreground-alt-200">
-          {jar.protocol}
-        </p>
+        <p className="italic font-normal text-xs text-foreground-alt-200">{jar.protocol}</p>
       </div>
     </div>
   );
@@ -98,22 +85,12 @@ const createUserAssetDataComponent = (
   const tokenPriceWithPrecision = (price * precisionAsNumber).toFixed();
 
   const depositTokenWei = wei.mul((ratio * 1e4).toFixed()).div(1e4);
-  const weiMulPrice = depositTokenWei
-    .mul(tokenPriceWithPrecision)
-    .div(precisionAsNumber);
+  const weiMulPrice = depositTokenWei.mul(tokenPriceWithPrecision).div(precisionAsNumber);
 
   return {
     wei: depositTokenWei,
-    tokens: bigNumberToTokenNumber(
-      depositTokenWei,
-      decimals,
-      decimals,
-    ).toString(),
-    tokensVisible: bigNumberToTokenNumber(
-      depositTokenWei,
-      decimals,
-      3,
-    ).toString(),
+    tokens: bigNumberToTokenNumber(depositTokenWei, decimals, decimals).toString(),
+    tokensVisible: bigNumberToTokenNumber(depositTokenWei, decimals, 3).toString(),
     tokensUSD: bigNumberToTokenNumber(weiMulPrice, decimals, 3),
   };
 };
@@ -179,10 +156,7 @@ export const getUserAssetDataWithPrices = (
   };
 };
 
-const formatImagePath = (
-  chain: string,
-  networks: Network[] | undefined,
-): string => {
+const formatImagePath = (chain: string, networks: Network[] | undefined): string => {
   const thisNetwork = networks?.find((network) => network.name === chain);
   if (thisNetwork) {
     return `/networks/${thisNetwork.name}.png`;
@@ -193,10 +167,8 @@ const formatImagePath = (
 
 const FarmsTableRowHeader: FC<Props> = ({ jar, simple, open }) => {
   const networks = useSelector(CoreSelectors.selectNetworks);
-  const totalTokensInJarAndFarm =
-    jar.depositTokensInJar.tokens + jar.depositTokensInFarm.tokens;
-  const depositTokenUSD =
-    jar.depositTokensInJar.tokensUSD + jar.depositTokensInFarm.tokensUSD;
+  const totalTokensInJarAndFarm = jar.depositTokensInJar.tokens + jar.depositTokensInFarm.tokens;
+  const depositTokenUSD = jar.depositTokensInJar.tokensUSD + jar.depositTokensInFarm.tokensUSD;
   const pendingPicklesAsDollars = jar.earnedPickles.tokensUSD;
   const picklesPending = jar.earnedPickles.tokensVisible;
   const depositTokenCountString = totalTokensInJarAndFarm + " Tokens";
@@ -204,12 +176,7 @@ const FarmsTableRowHeader: FC<Props> = ({ jar, simple, open }) => {
 
   return (
     <>
-      <RowCell
-        className={classNames(
-          !open && "rounded-bl-xl",
-          "rounded-tl-xl flex items-center",
-        )}
-      >
+      <RowCell className={classNames(!open && "rounded-bl-xl", "rounded-tl-xl flex items-center")}>
         <FarmComponentsIcons jar={jar} />
         {chainProtocol(jar, networks)}
       </RowCell>
@@ -217,9 +184,7 @@ const FarmsTableRowHeader: FC<Props> = ({ jar, simple, open }) => {
         <p className="font-title font-medium text-base leading-5">
           {formatDollars(pendingPicklesAsDollars)}
         </p>
-        <p className="font-normal text-xs text-foreground-alt-200">
-          {picklesPending} PICKLEs
-        </p>
+        <p className="font-normal text-xs text-foreground-alt-200">{picklesPending} PICKLEs</p>
       </RowCell>
       <RowCell>
         <div className="flex items-center">
@@ -228,16 +193,12 @@ const FarmsTableRowHeader: FC<Props> = ({ jar, simple, open }) => {
             <p className="font-title font-medium text-base leading-5">
               {formatDollars(depositTokenUSD)}
             </p>
-            <p className="font-normal text-xs text-foreground-alt-200">
-              {depositTokenCountString}
-            </p>
+            <p className="font-normal text-xs text-foreground-alt-200">{depositTokenCountString}</p>
           </div>
         </div>
       </RowCell>
       <RowCell>
-        <p className="font-title font-medium text-base leading-5">
-          {aprRangeString}
-        </p>
+        <p className="font-title font-medium text-base leading-5">{aprRangeString}</p>
       </RowCell>
       <RowCell className={classNames(simple && "rounded-r-xl")}>
         <p className="font-title font-medium text-base leading-5">
@@ -245,9 +206,7 @@ const FarmsTableRowHeader: FC<Props> = ({ jar, simple, open }) => {
         </p>
       </RowCell>
       {!simple && (
-        <RowCell
-          className={classNames(!open && "rounded-br-xl", "rounded-tr-xl w-10")}
-        >
+        <RowCell className={classNames(!open && "rounded-br-xl", "rounded-tr-xl w-10")}>
           <div className="flex justify-end pr-3">
             <ChevronDownIcon
               className={classNames(

--- a/v2/features/farms/Pagination.tsx
+++ b/v2/features/farms/Pagination.tsx
@@ -1,0 +1,88 @@
+import { FC, MouseEventHandler, ReactElement } from "react";
+import { useSelector } from "react-redux";
+import { useTranslation } from "next-i18next";
+import { ArrowRightIcon, ArrowLeftIcon } from "@heroicons/react/solid";
+
+import { useAppDispatch } from "v2/store";
+import { ControlsSelectors, setCurrentPage } from "v2/store/controls";
+import { CoreSelectors } from "v2/store/core";
+import { classNames } from "v2/utils";
+
+enum PageDirection {
+  Forward = 1,
+  Back = -1,
+}
+
+interface PaginationArrowProps {
+  currentPage: number;
+  pageCount: number;
+  onClick: MouseEventHandler;
+  type: "left" | "right";
+}
+
+const PaginationArrow: FC<PaginationArrowProps> = ({ currentPage, pageCount, onClick, type }) => {
+  const Icon = type === "left" ? ArrowLeftIcon : ArrowRightIcon;
+
+  return (
+    <Icon
+      className={classNames(
+        type === "left" && currentPage === 0 && "cursor-not-allowed text-foreground-alt-400",
+        type === "left" &&
+          currentPage !== 0 &&
+          "cursor-pointer hover:text-accent transition duration-300 ease-in-out text-foreground-alt-200",
+        type === "right" &&
+          currentPage + 1 === pageCount &&
+          "cursor-not-allowed text-foreground-alt-400",
+        type === "right" &&
+          currentPage + 1 !== pageCount &&
+          "cursor-pointer hover:text-accent transition duration-300 ease-in-out text-foreground-alt-200",
+        "w-5 h-5",
+      )}
+      onClick={onClick}
+    />
+  );
+};
+
+const Paginate: FC = () => {
+  const { t } = useTranslation("common");
+  const dispatch = useAppDispatch();
+  const { currentPage, itemsPerPage } = useSelector(ControlsSelectors.selectPaginateParams);
+  const jars = useSelector(CoreSelectors.selectFilteredAssets);
+
+  const pageCount = Math.ceil(jars.length / itemsPerPage);
+
+  const handlePageClick = (direction: PageDirection) => {
+    const newPage = currentPage + direction;
+
+    if (newPage < 0 || newPage >= pageCount) return;
+
+    dispatch(setCurrentPage(newPage));
+  };
+
+  if (jars.length === 0)
+    return <span className="text-foreground-alt-200">{t("v2.farms.noResults")}</span>;
+
+  return (
+    <>
+      <div className="flex items-center select-none">
+        <PaginationArrow
+          type="left"
+          currentPage={currentPage}
+          pageCount={pageCount}
+          onClick={() => handlePageClick(PageDirection.Back)}
+        />
+        <span className="px-3 text-foreground-alt-200">
+          {t("v2.farms.pagination", { current: currentPage + 1, total: pageCount })}
+        </span>
+        <PaginationArrow
+          type="right"
+          currentPage={currentPage}
+          pageCount={pageCount}
+          onClick={() => handlePageClick(PageDirection.Forward)}
+        />
+      </div>
+    </>
+  );
+};
+
+export default Paginate;

--- a/v2/store/controls.ts
+++ b/v2/store/controls.ts
@@ -31,15 +31,19 @@ export interface Filter {
   imageSrc: string;
 }
 
+export const itemsPerPage = 20;
+
 interface ControlsState {
   filters: Filter[];
   matchAllFilters: boolean;
   sort: Sort;
+  currentPage: number;
 }
 
 const initialState: ControlsState = {
   filters: [],
   matchAllFilters: false,
+  currentPage: 0,
   sort: {
     type: SortType.Earned,
     direction: "desc",
@@ -54,6 +58,7 @@ const controlsSlice = createSlice({
     // by react-select. We spread the array later so we can work with it.
     setFilters: (state, action: PayloadAction<readonly Filter[]>) => {
       state.filters = [...action.payload];
+      state.currentPage = 0;
     },
     setMatchAllFilters: (state, action: PayloadAction<boolean>) => {
       state.matchAllFilters = action.payload;
@@ -61,30 +66,34 @@ const controlsSlice = createSlice({
     setSort: (state, action: PayloadAction<Sort>) => {
       state.sort = action.payload;
     },
+    setCurrentPage: (state, action: PayloadAction<number>) => {
+      state.currentPage = action.payload;
+    },
   },
 });
 
 /**
  * Actions
  */
-export const {
-  setFilters,
-  setMatchAllFilters,
-  setSort,
-} = controlsSlice.actions;
+export const { setFilters, setMatchAllFilters, setSort, setCurrentPage } = controlsSlice.actions;
 
 /**
  * Selectors
  */
 const selectFilters = (state: RootState) => state.controls.filters;
-const selectMatchAllFilters = (state: RootState) =>
-  state.controls.matchAllFilters;
+const selectMatchAllFilters = (state: RootState) => state.controls.matchAllFilters;
 const selectSort = (state: RootState) => state.controls.sort;
+const selectPaginateParams = (state: RootState) => ({
+  currentPage: state.controls.currentPage,
+  itemsPerPage,
+  offset: state.controls.currentPage * itemsPerPage,
+});
 
 export const ControlsSelectors = {
   selectFilters,
   selectMatchAllFilters,
   selectSort,
+  selectPaginateParams,
 };
 
 export default controlsSlice.reducer;


### PR DESCRIPTION
Closes #319 

Required a little refactoring to get pagination working with [global] sorting. Also, by virtue of this solution being a bit of a retrofit, use of `getUserAssetDataWithPrices` in the `core` store seems a little out of place, but couldn't think of a more logical place for the function (other than a utility file), since it has other dependencies. 