### PR TITLE
Support for targeted gasLimit overrides

### DIFF
--- a/features/Gauges/JarGaugeCollapsible.tsx
+++ b/features/Gauges/JarGaugeCollapsible.tsx
@@ -50,6 +50,7 @@ import {
   getRatioStringAndPendingString,
   RatioAndPendingStrings,
 } from "features/MiniFarms/JarMiniFarmCollapsible";
+import { gasLimit, JarInteraction } from "util/gasLimits";
 
 interface DataProps {
   isZero?: boolean;
@@ -594,7 +595,9 @@ export const JarGaugeCollapsible: FC<{
         setExitButton(t("farms.withdrawingFromJar"));
         const withdrawTx = await jarContract
           .connect(signer)
-          .withdrawAll();
+          .withdrawAll(
+            gasLimit(jarContract.address, JarInteraction.WithdrawAll),
+          );
         await withdrawTx.wait();
         await sleep(10000);
         setExitButton(null);
@@ -1005,7 +1008,13 @@ export const JarGaugeCollapsible: FC<{
                     transferCallback: async () => {
                       return jarContract
                         .connect(signer)
-                        .withdraw(convertDecimals(withdrawAmount));
+                        .withdraw(
+                          convertDecimals(withdrawAmount),
+                          gasLimit(
+                            jarContract.address,
+                            JarInteraction.Withdraw,
+                          ),
+                        );
                     },
                     approval: false,
                   });

--- a/util/gasLimits.ts
+++ b/util/gasLimits.ts
@@ -24,8 +24,8 @@ interface TokenGasLimits {
 const tokenGasLimits: TokenGasLimits = {
   // LOOKS
   "0xb4EBc2C371182DeEa04B2264B9ff5AC4F0159C69": {
-    [JarInteraction.Withdraw]: 250000,
-    [JarInteraction.WithdrawAll]: 250000,
+    [JarInteraction.Withdraw]: 300000,
+    [JarInteraction.WithdrawAll]: 300000,
   },
 };
 

--- a/util/gasLimits.ts
+++ b/util/gasLimits.ts
@@ -1,0 +1,39 @@
+import { Overrides } from "ethers";
+
+export enum JarInteraction {
+  Deposit = "JarDeposit",
+  Withdraw = "JarWithdraw",
+  WithdrawAll = "JarWithdrawAll",
+}
+
+export enum GaugeInteraction {
+  DepositAll = "GaugeDepositAll",
+  GetReward = "GaugeGetReward",
+  Withdraw = "GaugeWithdraw",
+  Exit = "GaugeExit",
+}
+
+type Interaction = JarInteraction | GaugeInteraction;
+
+interface TokenGasLimits {
+  [tokenAddress: string]: {
+    [key in Interaction]?: number;
+  };
+}
+
+const tokenGasLimits: TokenGasLimits = {
+  // LOOKS
+  "0xb4EBc2C371182DeEa04B2264B9ff5AC4F0159C69": {
+    [JarInteraction.Withdraw]: 250000,
+    [JarInteraction.WithdrawAll]: 250000,
+  },
+};
+
+export const gasLimit = (
+  tokenAddress: string,
+  interaction: Interaction,
+): Overrides => {
+  const gasLimit = tokenGasLimits[tokenAddress][interaction];
+
+  return gasLimit ? { gasLimit } : {};
+};


### PR DESCRIPTION
This allows us to define gas limits per contract and specific interaction.

Step one is to add the entry to `tokenGasLimits`. We're using the exact contract address from pf-core. Define gas limit overrides using the enum helpers.

Finally, use the `gasLimit` helper when calling contracts.