### PR TITLE
fixed week grouping to use UTC to ensure accurate data

### DIFF
--- a/v2/features/dill/HistoricChart.tsx
+++ b/v2/features/dill/HistoricChart.tsx
@@ -48,10 +48,8 @@ const HistoricChart: FC = () => {
         tmp.ethAmount * tmp.ethPriceUsd;
       dillByWeek.push(tmp as DistributionDataPoint);
     });
-    // console.log(dillByWeek);
     if (chartMode === "monthly") {
       const dillByMonth = groupMonth(dillByWeek);
-      // console.log(dillByMonth);
       const monthKeys = Object.keys(dillByMonth) as Array<keyof typeof dillByMonth>;
       const dillByMonthAggregated = monthKeys.reduce<Array<DistributionDataPoint>>((acc, curr) => {
         const monthData = dillByMonth[curr].reduce<DistributionDataPoint>(
@@ -178,12 +176,8 @@ export type DistributionDataPoint = {
 const groupMonth = (dillStats: DistributionDataPoint[]) => {
   let byMonth: { [key: string]: Array<DistributionDataPoint> } = {};
   dillStats?.map((week) => {
-    console.log(week);
     const date = new Date(week["distributionTime"]);
-    console.log("DATE: ", date);
     const month = (date.getUTCFullYear() - 1970) * 12 + date.getUTCMonth();
-    console.log("MONTH: ", month);
-    console.log(month);
     byMonth[month] = byMonth[month] || [];
     byMonth[month].push(week);
   });

--- a/v2/features/dill/HistoricChart.tsx
+++ b/v2/features/dill/HistoricChart.tsx
@@ -10,7 +10,7 @@ import Skeleton from "@material-ui/lab/Skeleton";
 import { RadioGroup } from "@headlessui/react";
 
 import { CoreSelectors } from "v2/store/core";
-import { classNames } from "v2/utils";
+import { classNames, formatDate } from "v2/utils";
 import { DillWeek } from "picklefinance-core/lib/model/PickleModelJson";
 
 const HistoricChart: FC = () => {
@@ -29,12 +29,15 @@ const HistoricChart: FC = () => {
     const dillByWeek: DistributionDataPoint[] = [];
     dillStats.forEach((x, i) => {
       let rewardsUsd = x.weeklyPickleAmount * x.picklePriceUsd + x.weeklyEthAmount * x.ethPriceUsd;
+      const dDate = new Date(x.distributionTime);
       let tmp = {
         ...x,
         pickleAmount: x.weeklyPickleAmount,
         ethAmount: x.weeklyEthAmount,
         dillAmount: x.weeklyDillAmount,
-        distributionTime: new Date(x.distributionTime.toString().split("T")[0]).toDateString(),
+        distributionTime: `${dDate.getUTCFullYear()}-${
+          dDate.getUTCMonth() + 1
+        }-${dDate.getUTCDate()}`,
         rewardsUsd: rewardsUsd,
         totalRewardsUsd: 0,
         usdPerDill: rewardsUsd / x.totalDillAmount,
@@ -48,6 +51,7 @@ const HistoricChart: FC = () => {
     // console.log(dillByWeek);
     if (chartMode === "monthly") {
       const dillByMonth = groupMonth(dillByWeek);
+      // console.log(dillByMonth);
       const monthKeys = Object.keys(dillByMonth) as Array<keyof typeof dillByMonth>;
       const dillByMonthAggregated = monthKeys.reduce<Array<DistributionDataPoint>>((acc, curr) => {
         const monthData = dillByMonth[curr].reduce<DistributionDataPoint>(
@@ -64,7 +68,7 @@ const HistoricChart: FC = () => {
               ethPriceUsd: (acc2.ethPriceUsd || 0) + curr2.ethPriceUsd / length,
               rewardsUsd: (acc2.rewardsUsd || 0) + (curr2.rewardsUsd || 0),
               totalRewardsUsd: (acc2.totalRewardsUsd || 0) + (curr2.totalRewardsUsd || 0) / length,
-              distributionTime: monthToDate(curr as number).toDateString(),
+              distributionTime: monthToDate(curr as number).toUTCString(),
               usdPerDill: (acc2.usdPerDill || 0) + (curr2.usdPerDill || 0) / length,
             };
             return acc2;
@@ -174,8 +178,12 @@ export type DistributionDataPoint = {
 const groupMonth = (dillStats: DistributionDataPoint[]) => {
   let byMonth: { [key: string]: Array<DistributionDataPoint> } = {};
   dillStats?.map((week) => {
+    console.log(week);
     const date = new Date(week["distributionTime"]);
-    const month = (date.getFullYear() - 1970) * 12 + date.getMonth();
+    console.log("DATE: ", date);
+    const month = (date.getUTCFullYear() - 1970) * 12 + date.getUTCMonth();
+    console.log("MONTH: ", month);
+    console.log(month);
     byMonth[month] = byMonth[month] || [];
     byMonth[month].push(week);
   });

--- a/v2/features/dill/RevenueStats.tsx
+++ b/v2/features/dill/RevenueStats.tsx
@@ -22,7 +22,6 @@ const RevenueStats: FC<Props> = ({ dill }) => {
   const blockPerWeek = (1 / Chains.get(ChainNetwork.Ethereum).secondsPerBlock) * 60 * 7 * 24 * 60;
 
   const { dillWeeks, totalPickle, pickleLocked, totalDill } = dill;
-  console.log(dillWeeks[dillWeeks.length - 1]);
 
   if (!dillWeeks || !totalPickle || !picklePerBlock || !blockPerWeek) return <></>;
   const upcomingDistribution = dillWeeks[dillWeeks.length - 1];


### PR DESCRIPTION
I noticed today while working on something else, that on the dill chart, a distribution paid out 9/1 at 00:00:00 was being included in my august data because where I am it was paid out in august. Thought I fixed this kind of thing already but this should be good now. Need @mannyreimi88 to confirm this still works in HK.