### PR TITLE
Turn Powered by Wido into Link

### DIFF
--- a/v2/components/Link.tsx
+++ b/v2/components/Link.tsx
@@ -9,9 +9,10 @@ interface Props extends HTMLAttributes<HTMLElement> {
   external?: boolean;
   active?: boolean;
   primary?: boolean;
+  iconClassName?: string;
 }
 
-const AppLink: FC<Props> = ({ active, children, className, external, href, primary, onClick }) => {
+const AppLink: FC<Props> = ({ active, children, className, iconClassName, external, href, primary, onClick }) => {
   return (
     <Link href={href}>
       <a
@@ -31,6 +32,7 @@ const AppLink: FC<Props> = ({ active, children, className, external, href, prima
             className={classNames(
               primary ? "text-accent" : "text-foreground",
               "group-hover:text-primary-light ml-2 flex-shrink-0 h-4 w-4 transition duration-300 ease-in-out",
+              iconClassName
             )}
             aria-hidden="true"
           />

--- a/v2/features/farms/flows/zap/Form.tsx
+++ b/v2/features/farms/flows/zap/Form.tsx
@@ -23,6 +23,7 @@ import { classNames } from "v2/utils";
 import { ChainNetwork } from "picklefinance-core";
 import Spinner from "v2/components/Spinner";
 import { getWidoSpender, ZERO_ADDRESS } from "wido";
+import Link from "v2/components/Link";
 
 interface Props {
   jar: JarWithData;
@@ -269,7 +270,13 @@ const Form: FC<Props> = ({ jar, nextStep, zapTokens, balances }) => {
         </Button>
       )}
       {jar.chain == ChainNetwork.Ethereum && (
-        <p className="pt-3 font-bold text-foreground-alt-300">{t("v2.actions.poweredBy")}</p>
+        <Link href={"https://joinwido.com"}
+          className="pt-3 font-bold text-foreground-alt-300 w-full place-content-center text-base"
+          iconClassName="text-foreground-alt-300"
+          external
+        >
+          {t("v2.actions.poweredBy")}
+        </Link>
       )}
     </>
   );


### PR DESCRIPTION
Hey Pickle fam👋 , this PR adds a link to the Powered by Wido text. Would this work?

Before:
![image](https://user-images.githubusercontent.com/26041347/213678049-5b2ceba4-450f-46af-9591-39fb7de21e6d.png)

After:
![image](https://user-images.githubusercontent.com/26041347/213677730-945de02c-ba9f-4575-ae50-1a5539c1e739.png)
